### PR TITLE
fix: sync cursor to Neovim on mouse click

### DIFF
--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -359,9 +359,13 @@ impl GodotNeovimPlugin {
 
         let line_count = editor.get_line_count();
         let safe_line = line.min(line_count - 1).max(0);
+        let safe_col = column.max(0);
 
         editor.set_caret_line(safe_line);
-        editor.set_caret_column(column.max(0));
+        editor.set_caret_column(safe_col);
+
+        // Update last_synced_cursor to prevent sync loop
+        self.last_synced_cursor = (safe_line, safe_col);
     }
 
     /// Sync buffer from Neovim to Godot editor


### PR DESCRIPTION
fixed https://github.com/shiena/godot-neovim/discussions/3
Connect to mouse click events to detect cursor position changes.

- Add last_synced_cursor field to track synced position
- Update sync_cursor_from_grid to set last_synced_cursor
- Detect mouse left click in input() and sync cursor via deferred call
- Skip caret_changed sync in Insert/Replace modes to prevent freeze
- Add editor focus check to avoid unnecessary sync