### PR TITLE
fix: move cursor to changed position on undo/redo

### DIFF
--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -404,7 +404,10 @@ impl IEditorPlugin for GodotNeovimPlugin {
 
     fn input(&mut self, event: Gd<godot::classes::InputEvent>) {
         // Handle mouse click events - sync cursor position after click
-        if let Ok(mouse_event) = event.clone().try_cast::<godot::classes::InputEventMouseButton>() {
+        if let Ok(mouse_event) = event
+            .clone()
+            .try_cast::<godot::classes::InputEventMouseButton>()
+        {
             // Only handle left mouse button press when editor has focus
             if mouse_event.is_pressed()
                 && mouse_event.get_button_index() == godot::global::MouseButton::LEFT


### PR DESCRIPTION
## Summary
- Fix cursor not moving to the changed position when using `u` (undo) or `Ctrl+R` (redo)
- Compare buffer before and after undo/redo to find the exact line and column where the change occurred
- Move cursor to that position, matching Neovim's behavior

## Test plan
1. Open a script
2. `i` to enter Insert mode, type some text at a specific position
3. `Escape` to return to Normal mode
4. `H` to move cursor to top of screen
5. `u` to undo
6. Verify cursor moves back to where text was inserted
7. `Ctrl+R` to redo, verify cursor moves correctly
