### PR TITLE
fix: prevent freeze by updating last_synced_cursor before setting caret

### DIFF
--- a/src/plugin/motions.rs
+++ b/src/plugin/motions.rs
@@ -307,6 +307,10 @@ impl GodotNeovimPlugin {
 
     /// Move cursor to specified position and sync with Neovim
     pub(super) fn move_cursor_to(&mut self, line: i32, col: i32) {
+        // Update last_synced_cursor BEFORE setting caret to prevent
+        // caret_changed signal from triggering extra sync_cursor_to_neovim
+        self.last_synced_cursor = (line, col);
+
         if let Some(ref mut editor) = self.current_editor {
             editor.set_caret_line(line);
             editor.set_caret_column(col);

--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -361,11 +361,12 @@ impl GodotNeovimPlugin {
         let safe_line = line.min(line_count - 1).max(0);
         let safe_col = column.max(0);
 
+        // Update last_synced_cursor BEFORE setting caret to prevent
+        // caret_changed signal from triggering sync_cursor_to_neovim
+        self.last_synced_cursor = (safe_line, safe_col);
+
         editor.set_caret_line(safe_line);
         editor.set_caret_column(safe_col);
-
-        // Update last_synced_cursor to prevent sync loop
-        self.last_synced_cursor = (safe_line, safe_col);
     }
 
     /// Sync buffer from Neovim to Godot editor
@@ -403,6 +404,10 @@ impl GodotNeovimPlugin {
 
             let line_count = editor.get_line_count();
             let safe_line = target_line.min(line_count - 1);
+
+            // Update last_synced_cursor BEFORE setting caret to prevent
+            // caret_changed signal from triggering sync_cursor_to_neovim
+            self.last_synced_cursor = (safe_line, target_col);
 
             editor.set_caret_line(safe_line);
             editor.set_caret_column(target_col);


### PR DESCRIPTION
Update last_synced_cursor BEFORE setting caret position to prevent caret_changed signal from triggering extra sync_cursor_to_neovim calls.

Fixed in:
- sync_cursor_from_grid (process_neovim_updates)
- sync_buffer_from_neovim (send_keys processing)
- move_cursor_to (all motion commands)