### PR TITLE
feat: add :version command to show version in status label

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Once the plugin is enabled:
 | Command | Description |
 |---------|-------------|
 | `:help`, `:h` | Open GodotNeovim help |
+| `:version`, `:ver` | Show version in status label |
 | `:e` | Open quick open dialog for scripts |
 | `:e {file}` | Open specified script file |
 | `:e!` | Discard changes and reload |

--- a/addons/godot-neovim/GodotNeovim.gd
+++ b/addons/godot-neovim/GodotNeovim.gd
@@ -150,6 +150,7 @@
 ##
 ## [br][b]Ex Commands[/b][br]
 ## [code]:help :h[/code] - Open this help[br]
+## [code]:version :ver[/code] - Show version in status label[br]
 ## [code]:w :wa[/code] - Save / Save all[br]
 ## [code]:q :qa[/code] - Close / Close all[br]
 ## [code]:wq :x[/code] - Save and close[br]

--- a/src/plugin/commands.rs
+++ b/src/plugin/commands.rs
@@ -23,9 +23,11 @@ impl GodotNeovimPlugin {
         self.command_mode = false;
         self.command_buffer.clear();
 
-        // Restore mode display
-        let display_cursor = (self.current_cursor.0 + 1, self.current_cursor.1);
-        self.update_mode_display_with_cursor(&self.current_mode.clone(), Some(display_cursor));
+        // Restore mode display (unless showing version)
+        if !self.show_version {
+            let display_cursor = (self.current_cursor.0 + 1, self.current_cursor.1);
+            self.update_mode_display_with_cursor(&self.current_mode.clone(), Some(display_cursor));
+        }
     }
 
     /// Update command display in mode label
@@ -209,6 +211,10 @@ impl GodotNeovimPlugin {
                 // :help - open GodotNeovim help
                 else if cmd == "help" || cmd == "h" {
                     self.cmd_help();
+                }
+                // :version - show version in status label
+                else if cmd == "version" || cmd == "ver" {
+                    self.cmd_version();
                 } else {
                     godot_warn!("[godot-neovim] Unknown command: {}", cmd);
                 }
@@ -1012,6 +1018,12 @@ impl GodotNeovimPlugin {
             member_name: None,
             member_type: HelpMemberType::Class,
         });
+    }
+
+    /// :version - Show godot-neovim version in status label
+    pub(super) fn cmd_version(&mut self) {
+        self.show_version = true;
+        self.update_version_display();
     }
 
     /// K - Open documentation for word under cursor

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -253,6 +253,9 @@ pub struct GodotNeovimPlugin {
     /// Direct LSP client for Godot LSP server
     #[init(val = None)]
     godot_lsp: Option<Arc<GodotLspClient>>,
+    /// Temporary version display flag (cleared on next operation)
+    #[init(val = false)]
+    show_version: bool,
 }
 
 #[godot_api]
@@ -1050,6 +1053,9 @@ impl GodotNeovimPlugin {
     }
 
     fn update_mode_display_with_cursor(&mut self, mode: &str, cursor: Option<(i64, i64)>) {
+        // Clear version display flag (any operation returns to normal display)
+        self.show_version = false;
+
         let Some(ref mut label) = self.mode_label else {
             return;
         };
@@ -1098,6 +1104,17 @@ impl GodotNeovimPlugin {
             };
             editor.set_caret_type(caret_type);
         }
+    }
+
+    /// Update status label to show version
+    pub(crate) fn update_version_display(&mut self) {
+        let Some(ref mut label) = self.mode_label else {
+            return;
+        };
+        let display_text = format!(" godot-neovim v{} ", VERSION);
+        label.set_text(&display_text);
+        // White color for version display
+        label.add_theme_color_override("font_color", Color::from_rgb(1.0, 1.0, 1.0));
     }
 }
 


### PR DESCRIPTION
- Add :ver and :version commands to display godot-neovim version
- Version is shown temporarily in the status label
- Skip mode display restore when showing version
- Any subsequent operation returns to normal mode display
- Update documentation in README.md and GodotNeovim.gd