### PR TITLE
feat: add dynamic input mode switching with :hybrid/:strict commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ godot-neovim integrates Neovim into Godot's script editor, allowing you to use t
 ## Features
 
 - Real Neovim backend (not just keybinding emulation)
-- Mode indicator with cursor position (e.g., `NORMAL 123:45`)
+- Mode indicator with input mode and cursor position (e.g., `NORMAL (Hybrid) 123:45`)
 - Cursor synchronization between Godot and Neovim
 - Support for count prefixes (e.g., `4j`, `10gg`)
 - Support for operator-pending commands (e.g., `gg`, `dd`, `yy`)
@@ -368,6 +368,8 @@ Once the plugin is enabled:
 |---------|-------------|
 | `:help`, `:h` | Open GodotNeovim help |
 | `:version`, `:ver` | Show version in status label |
+| `:hybrid` | Switch to Hybrid input mode |
+| `:strict` | Switch to Strict input mode |
 | `:e` | Open quick open dialog for scripts |
 | `:e {file}` | Open specified script file |
 | `:e!` | Discard changes and reload |

--- a/addons/godot-neovim/GodotNeovim.gd
+++ b/addons/godot-neovim/GodotNeovim.gd
@@ -151,6 +151,8 @@
 ## [br][b]Ex Commands[/b][br]
 ## [code]:help :h[/code] - Open this help[br]
 ## [code]:version :ver[/code] - Show version in status label[br]
+## [code]:hybrid[/code] - Switch to Hybrid input mode[br]
+## [code]:strict[/code] - Switch to Strict input mode[br]
 ## [code]:w :wa[/code] - Save / Save all[br]
 ## [code]:q :qa[/code] - Close / Close all[br]
 ## [code]:wq :x[/code] - Save and close[br]

--- a/src/plugin/commands.rs
+++ b/src/plugin/commands.rs
@@ -1,6 +1,7 @@
 //! Command-line mode and Ex commands
 
 use super::{CodeEditExt, GodotNeovimPlugin};
+use crate::settings;
 use godot::classes::{EditorInterface, Input, InputEventKey, ResourceSaver};
 use godot::global::Key;
 use godot::prelude::*;
@@ -215,6 +216,12 @@ impl GodotNeovimPlugin {
                 // :version - show version in status label
                 else if cmd == "version" || cmd == "ver" {
                     self.cmd_version();
+                }
+                // :hybrid / :strict - switch input mode
+                else if cmd == "hybrid" {
+                    self.cmd_set_input_mode(settings::InputMode::Hybrid);
+                } else if cmd == "strict" {
+                    self.cmd_set_input_mode(settings::InputMode::Strict);
                 } else {
                     godot_warn!("[godot-neovim] Unknown command: {}", cmd);
                 }
@@ -1024,6 +1031,27 @@ impl GodotNeovimPlugin {
     pub(super) fn cmd_version(&mut self) {
         self.show_version = true;
         self.update_version_display();
+    }
+
+    /// :hybrid / :strict - Set input mode
+    pub(super) fn cmd_set_input_mode(&mut self, mode: settings::InputMode) {
+        // Temporarily disconnect settings signal to avoid borrow conflict
+        // (set_input_mode triggers settings_changed signal synchronously)
+        let editor = EditorInterface::singleton();
+        if let Some(mut editor_settings) = editor.get_editor_settings() {
+            let callable = self.base().callable("on_settings_changed");
+            editor_settings.disconnect("settings_changed", &callable);
+
+            // Now safe to change setting
+            settings::set_input_mode(mode);
+
+            // Reconnect signal
+            editor_settings.connect("settings_changed", &callable);
+        }
+
+        // Update display to show new mode
+        let display_cursor = (self.current_cursor.0 + 1, self.current_cursor.1);
+        self.update_mode_display_with_cursor(&self.current_mode.clone(), Some(display_cursor));
     }
 
     /// K - Open documentation for word under cursor

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -709,7 +709,9 @@ impl GodotNeovimPlugin {
     fn on_script_changed(&mut self, script: Option<Gd<godot::classes::Script>>) {
         // Handle null script (e.g., when all scripts are closed)
         let Some(script) = script else {
-            crate::verbose_print!("[godot-neovim] on_script_changed: null script, clearing references");
+            crate::verbose_print!(
+                "[godot-neovim] on_script_changed: null script, clearing references"
+            );
             self.current_editor = None;
             self.mode_label = None;
             self.current_script_path.clear();
@@ -1072,11 +1074,18 @@ impl GodotNeovimPlugin {
             _ => mode,
         };
 
+        // Get input mode for display
+        let input_mode = settings::get_input_mode();
+        let input_mode_name = match input_mode {
+            settings::InputMode::Hybrid => "Hybrid",
+            settings::InputMode::Strict => "Strict",
+        };
+
         // Format with cursor position if available
         let display_text = if let Some((line, col)) = cursor {
-            format!(" {} {}:{} ", mode_name, line, col)
+            format!(" {} ({}) {}:{} ", mode_name, input_mode_name, line, col)
         } else {
-            format!(" {} ", mode_name)
+            format!(" {} ({}) ", mode_name, input_mode_name)
         };
 
         label.set_text(&display_text);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -120,7 +120,11 @@ pub fn initialize_settings() {
     }
 
     // Set initial value for timeoutlen (p_basic=false: advanced setting, hidden by default)
-    settings.set_initial_value(SETTING_TIMEOUTLEN, &Variant::from(DEFAULT_TIMEOUTLEN_MS), false);
+    settings.set_initial_value(
+        SETTING_TIMEOUTLEN,
+        &Variant::from(DEFAULT_TIMEOUTLEN_MS),
+        false,
+    );
 
     // Add property info for timeoutlen (integer with range)
     #[allow(deprecated)]
@@ -205,6 +209,19 @@ pub fn get_input_mode() -> InputMode {
     }
 
     InputMode::default()
+}
+
+/// Set input mode in EditorSettings
+pub fn set_input_mode(mode: InputMode) {
+    let editor = EditorInterface::singleton();
+    let Some(mut settings) = editor.get_editor_settings() else {
+        return;
+    };
+    let value = match mode {
+        InputMode::Hybrid => 0i64,
+        InputMode::Strict => 1i64,
+    };
+    settings.set_setting(SETTING_INPUT_MODE, &Variant::from(value));
 }
 
 /// Get the configured neovim clean mode


### PR DESCRIPTION
- Display current input mode in status label (e.g., "NORMAL (Hybrid) 123:45")
- Add :hybrid command to switch to Hybrid input mode (IME support)
- Add :strict command to switch to Strict input mode (full Neovim control)
- Add set_input_mode() function to settings.rs for programmatic mode changes
- Temporarily disconnect settings_changed signal during mode switch to avoid borrow conflict