### PR TITLE
feat: Support Neovim operations in float windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ godot-neovim integrates Neovim into Godot's script editor, allowing you to use t
 - Real Neovim backend (not just keybinding emulation)
 - Mode indicator with cursor position (e.g., `NORMAL 123:45`)
 - Cursor synchronization between Godot and Neovim
+- Float window support (undocked script editor panels)
 - Mouse drag selection syncs to Neovim visual mode
 - Support for count prefixes (e.g., `4j`, `10gg`)
 - Support for operator-pending commands (e.g., `gg`, `dd`, `yy`)

--- a/src/neovim/handler.rs
+++ b/src/neovim/handler.rs
@@ -322,7 +322,10 @@ impl NeovimHandler {
         };
 
         let mut events = self.buf_events.lock().await;
-        events.push_back(BufEvent::ModifiedChanged { _buf: buf, modified });
+        events.push_back(BufEvent::ModifiedChanged {
+            _buf: buf,
+            modified,
+        });
         self.has_buf_events.store(true, Ordering::SeqCst);
     }
 

--- a/src/plugin/commands/mode.rs
+++ b/src/plugin/commands/mode.rs
@@ -1,6 +1,7 @@
 //! Command-line mode management: open/close, history, execute
 
 use super::super::GodotNeovimPlugin;
+use godot::classes::Label;
 use godot::prelude::*;
 
 impl GodotNeovimPlugin {
@@ -10,10 +11,16 @@ impl GodotNeovimPlugin {
         self.command_mode = true;
         self.command_buffer = ":".to_string();
 
-        // Show command in mode label
+        // Show command in mode label with yellow color
         if let Some(ref mut label) = self.mode_label {
             label.set_text(":");
+            Self::set_command_mode_color(label);
         }
+    }
+
+    /// Set yellow color for command mode
+    fn set_command_mode_color(label: &mut Gd<Label>) {
+        label.add_theme_color_override("font_color", Color::from_rgb(1.0, 1.0, 0.4));
     }
 
     /// Close command-line mode

--- a/src/plugin/editor.rs
+++ b/src/plugin/editor.rs
@@ -1,10 +1,60 @@
 //! Editor management: finding CodeEdit, script change handling
 
 use super::GodotNeovimPlugin;
-use godot::classes::{CodeEdit, Control, EditorInterface};
+use godot::classes::{CodeEdit, Control, EditorInterface, Window};
 use godot::prelude::*;
 
 impl GodotNeovimPlugin {
+    /// Check if current CodeEdit is in a float window and connect to gui_input signal
+    pub(super) fn update_float_window_connection(&mut self) {
+        let Some(ref editor) = self.current_editor else {
+            crate::verbose_print!("[godot-neovim] update_float_window: no current_editor");
+            return;
+        };
+
+        // Get the window containing the CodeEdit
+        let Some(window) = editor.get_window() else {
+            crate::verbose_print!("[godot-neovim] update_float_window: editor has no window");
+            return;
+        };
+
+        // Check if this is a float window (not the main window)
+        // Float windows are children of EditorNode, main window is the root window
+        let main_window = EditorInterface::singleton()
+            .get_base_control()
+            .and_then(|c| c.get_window());
+
+        let is_float_window = match main_window {
+            Some(ref main) => {
+                let is_float = window.instance_id() != main.instance_id();
+                crate::verbose_print!(
+                    "[godot-neovim] update_float_window: editor_window={} (id={}), main_window={} (id={}), is_float={}",
+                    window.get_name(),
+                    window.instance_id(),
+                    main.get_name(),
+                    main.instance_id(),
+                    is_float
+                );
+                is_float
+            }
+            None => {
+                crate::verbose_print!("[godot-neovim] update_float_window: no main window found");
+                false
+            }
+        };
+
+        // Always connect gui_input signal - it will check is_in_float_window() internally
+        // This ensures we catch input in float windows
+        self.connect_gui_input_signal();
+
+        if is_float_window {
+            crate::verbose_print!(
+                "[godot-neovim] CodeEdit is in float window: {}",
+                window.get_name()
+            );
+        }
+    }
+
     /// Delete a buffer from Neovim by path
     pub(super) fn delete_neovim_buffer(&self, path: &str) {
         let Some(ref neovim) = self.neovim else {
@@ -61,12 +111,35 @@ impl GodotNeovimPlugin {
             }
             if let Some(mut status_bar) = self.find_status_bar(code_edit.clone().upcast()) {
                 // Check if already in this status bar
-                if let Some(mut parent) = label.get_parent() {
+                if let Some(parent) = label.get_parent() {
                     if parent.instance_id() == status_bar.instance_id() {
                         return; // Already in correct position
                     }
-                    // Remove from current parent
-                    parent.remove_child(label);
+
+                    // Check if windows are different (float/undock case)
+                    // Moving nodes between windows causes Windows display server errors
+                    let label_window = label.get_window();
+                    let status_bar_window = status_bar.get_window();
+                    let windows_differ = match (&label_window, &status_bar_window) {
+                        (Some(lw), Some(sw)) => lw.instance_id() != sw.instance_id(),
+                        _ => false,
+                    };
+
+                    if windows_differ {
+                        // Different windows - recreate label instead of moving
+                        // This avoids transient_parent errors on Windows
+                        crate::verbose_print!(
+                            "[godot-neovim] Mode label in different window, recreating"
+                        );
+                        if let Some(mut old_label) = self.mode_label.take() {
+                            old_label.queue_free();
+                        }
+                        self.create_mode_label();
+                        return;
+                    }
+
+                    // Same window - just move the label
+                    parent.clone().remove_child(label);
                 }
 
                 // Add to status bar
@@ -83,8 +156,20 @@ impl GodotNeovimPlugin {
         self.current_editor = None;
 
         let editor = EditorInterface::singleton();
+
+        // First, try to get the focused CodeEdit directly via gui_get_focus_owner
+        // This works for both docked and floating windows
+        if let Some(code_edit) = self.get_focused_code_edit_direct() {
+            crate::verbose_print!("[godot-neovim] Found focused CodeEdit (direct)");
+            self.current_editor = Some(code_edit);
+            self.connect_caret_changed_signal();
+            self.connect_resized_signal();
+            self.update_float_window_connection();
+            return;
+        }
+
         if let Some(script_editor) = editor.get_script_editor() {
-            // Try to find the currently focused CodeEdit first
+            // Try to find the currently focused CodeEdit by traversing ScriptEditor
             if let Some(code_edit) =
                 self.find_focused_code_edit(script_editor.clone().upcast::<Control>())
             {
@@ -92,6 +177,7 @@ impl GodotNeovimPlugin {
                 self.current_editor = Some(code_edit);
                 self.connect_caret_changed_signal();
                 self.connect_resized_signal();
+                self.update_float_window_connection();
                 return;
             }
             // Fallback: find visible CodeEdit
@@ -101,8 +187,102 @@ impl GodotNeovimPlugin {
                 self.current_editor = Some(code_edit);
                 self.connect_caret_changed_signal();
                 self.connect_resized_signal();
+                self.update_float_window_connection();
             }
         }
+    }
+
+    /// Try to get focused CodeEdit directly from any window's viewport
+    /// This works for floating windows where the CodeEdit is not a child of ScriptEditor
+    fn get_focused_code_edit_direct(&self) -> Option<Gd<CodeEdit>> {
+        let editor = EditorInterface::singleton();
+        let base_control = editor.get_base_control()?;
+
+        // First try the main viewport
+        let main_viewport = base_control.get_viewport()?;
+        if let Some(focus_owner) = main_viewport.gui_get_focus_owner() {
+            if let Ok(code_edit) = focus_owner.try_cast::<CodeEdit>() {
+                return Some(code_edit);
+            }
+        }
+
+        // Float windows are managed by EditorNode, not as children of root window.
+        // We need to find EditorNode by traversing up from base_control
+        // and then search its children for WindowWrapper/Window nodes.
+        let editor_node = self.find_editor_node(base_control.clone().upcast())?;
+        crate::verbose_print!(
+            "[godot-neovim] Found EditorNode: {} (children={})",
+            editor_node.get_name(),
+            editor_node.get_child_count()
+        );
+        self.find_focused_code_edit_in_subwindows(editor_node)
+    }
+
+    /// Find EditorNode by traversing up the node hierarchy
+    fn find_editor_node(&self, node: Gd<Node>) -> Option<Gd<Node>> {
+        let mut current = node;
+        loop {
+            let class_name = current.get_class().to_string();
+            if class_name == "EditorNode" {
+                return Some(current);
+            }
+            current = current.get_parent()?;
+        }
+    }
+
+    /// Recursively search for focused CodeEdit in all subwindows
+    fn find_focused_code_edit_in_subwindows(&self, node: Gd<Node>) -> Option<Gd<CodeEdit>> {
+        // If this is a Window, check its focus owner or search for CodeEdit directly
+        if let Ok(window) = node.clone().try_cast::<Window>() {
+            let window_has_focus = window.has_focus();
+
+            // First try gui_get_focus_owner
+            if let Some(focus_owner) = window.gui_get_focus_owner() {
+                if let Ok(code_edit) = focus_owner.try_cast::<CodeEdit>() {
+                    return Some(code_edit);
+                }
+            }
+
+            // If window has focus (OS-level), search for any CodeEdit in this window
+            // Float windows won't report gui_get_focus_owner correctly when called from main window
+            if window_has_focus {
+                if let Some(code_edit) = self.find_first_code_edit_in_node(window.upcast()) {
+                    return Some(code_edit);
+                }
+            }
+        }
+
+        // Search children for more windows
+        let count = node.get_child_count();
+        for i in 0..count {
+            if let Some(child) = node.get_child(i) {
+                if let Some(code_edit) = self.find_focused_code_edit_in_subwindows(child) {
+                    return Some(code_edit);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Recursively find the first CodeEdit in a node tree (for focused windows)
+    fn find_first_code_edit_in_node(&self, node: Gd<Node>) -> Option<Gd<CodeEdit>> {
+        // Check if this node is a CodeEdit
+        if let Ok(code_edit) = node.clone().try_cast::<CodeEdit>() {
+            return Some(code_edit);
+        }
+
+        // Search children
+        let count = node.get_child_count();
+        for i in 0..count {
+            if let Some(child) = node.get_child(i) {
+                if let Some(code_edit) = self.find_first_code_edit_in_node(child) {
+                    return Some(code_edit);
+                }
+            }
+        }
+
+        None
     }
 
     /// Recursively find focused CodeEdit
@@ -153,14 +333,55 @@ impl GodotNeovimPlugin {
         None
     }
 
-    /// Check if editor has focus
-    pub(super) fn editor_has_focus(&self) -> bool {
+    /// Check if editor has focus, updating current_editor if a different CodeEdit has focus
+    pub(super) fn editor_has_focus(&mut self) -> bool {
+        // First check if current_editor has focus
         if let Some(ref editor) = self.current_editor {
-            // Check if editor instance is still valid (not freed)
-            if editor.is_instance_valid() {
-                return editor.has_focus();
+            if editor.is_instance_valid() && editor.has_focus() {
+                // Update float window connection if needed (checks internally if already connected)
+                self.update_float_window_connection();
+                return true;
             }
+            crate::verbose_print!(
+                "[godot-neovim] current_editor exists but no focus (valid={}, has_focus={})",
+                editor.is_instance_valid(),
+                if editor.is_instance_valid() {
+                    editor.has_focus()
+                } else {
+                    false
+                }
+            );
         }
+
+        // Current editor doesn't have focus - check if a different CodeEdit has focus
+        // This handles the case when the editor is floated to a different window
+        crate::verbose_print!("[godot-neovim] Searching for focused CodeEdit in all windows...");
+        if let Some(focused_code_edit) = self.get_focused_code_edit_direct() {
+            // Check if this is a different CodeEdit
+            let is_different = match &self.current_editor {
+                Some(current) => current.instance_id() != focused_code_edit.instance_id(),
+                None => true,
+            };
+
+            if is_different {
+                crate::verbose_print!(
+                    "[godot-neovim] Switching to focused CodeEdit (float/dock change)"
+                );
+                self.current_editor = Some(focused_code_edit);
+                self.connect_caret_changed_signal();
+                self.connect_resized_signal();
+                self.reposition_mode_label();
+            } else {
+                crate::verbose_print!("[godot-neovim] Same CodeEdit found in focused window");
+            }
+
+            // Update float window connection for input handling
+            self.update_float_window_connection();
+
+            // Found a CodeEdit in a focused window - return true regardless
+            return true;
+        }
+
         false
     }
 }

--- a/src/plugin/input/command.rs
+++ b/src/plugin/input/command.rs
@@ -10,8 +10,10 @@ impl GodotNeovimPlugin {
         key_event: &Gd<godot::classes::InputEventKey>,
     ) {
         let keycode = key_event.get_keycode();
+        let ctrl_pressed = key_event.is_ctrl_pressed();
 
-        if keycode == Key::ESCAPE {
+        // Escape or Ctrl+[ closes command line
+        if keycode == Key::ESCAPE || (ctrl_pressed && keycode == Key::BRACKETLEFT) {
             self.close_command_line();
         } else if keycode == Key::ENTER {
             self.execute_command();

--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -615,7 +615,8 @@ impl GodotNeovimPlugin {
         // without triggering a mode_change event (is_visual would otherwise stay false)
         let mut is_visual = Self::is_visual_mode(&self.current_mode);
         let mut was_visual = is_visual;
-        let mut visual_line_mode = self.current_mode == "V";
+        // Use visual_mode_type since Neovim returns "visual" for all visual modes
+        let mut visual_line_mode = self.visual_mode_type == 'V';
 
         // Process state update from redraw events
         if let Some((ref mode, cursor)) = state_from_redraw {
@@ -632,7 +633,8 @@ impl GodotNeovimPlugin {
             // Check if entering/leaving visual mode
             was_visual = Self::is_visual_mode(&old_mode);
             is_visual = Self::is_visual_mode(mode);
-            visual_line_mode = mode == "V";
+            // Use visual_mode_type since Neovim returns "visual" for all visual modes
+            visual_line_mode = self.visual_mode_type == 'V';
             let entering_visual = is_visual && !was_visual;
             let leaving_visual = was_visual && !is_visual;
 

--- a/src/plugin/state.rs
+++ b/src/plugin/state.rs
@@ -108,10 +108,19 @@ impl GodotNeovimPlugin {
         }
 
         // Get mode display name
+        // Note: Neovim returns "visual" for all visual modes (v, V, Ctrl+V)
+        // We use visual_mode_type to distinguish between them
         let mode_name = match mode {
             "n" | "normal" => "NORMAL",
             "i" | "insert" => "INSERT",
-            "v" | "visual" => "VISUAL",
+            "v" | "visual" => {
+                // Use tracked visual mode type since Neovim returns "visual" for all
+                match self.visual_mode_type {
+                    'V' => "V-LINE",
+                    '\x16' => "V-BLOCK",
+                    _ => "VISUAL",
+                }
+            }
             "V" | "visual-line" => "V-LINE",
             "\x16" | "^V" | "CTRL-V" | "visual-block" => "V-BLOCK",
             "c" | "command" => "COMMAND",

--- a/src/plugin/ui.rs
+++ b/src/plugin/ui.rs
@@ -152,4 +152,33 @@ impl GodotNeovimPlugin {
             crate::verbose_print!("[godot-neovim] Disconnected from resized signal");
         }
     }
+
+    /// Connect to CodeEdit gui_input signal for float window input handling
+    /// Float windows don't receive input through EditorPlugin.input()
+    pub(super) fn connect_gui_input_signal(&mut self) {
+        let callable = self.base().callable("on_codeedit_gui_input");
+
+        let Some(ref mut editor) = self.current_editor else {
+            return;
+        };
+
+        if !editor.is_connected("gui_input", &callable) {
+            editor.connect("gui_input", &callable);
+            crate::verbose_print!("[godot-neovim] Connected to gui_input signal");
+        }
+    }
+
+    /// Disconnect from CodeEdit gui_input signal
+    pub(super) fn disconnect_gui_input_signal(&mut self) {
+        let callable = self.base().callable("on_codeedit_gui_input");
+
+        let Some(ref mut editor) = self.current_editor else {
+            return;
+        };
+
+        if editor.is_connected("gui_input", &callable) {
+            editor.disconnect("gui_input", &callable);
+            crate::verbose_print!("[godot-neovim] Disconnected from gui_input signal");
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Support Neovim operations in float windows (when editor panel is undocked/floated) (fixed https://github.com/shiena/godot-neovim/discussions/16)
- Fix transient_parent error when moving mode label between windows
- Fix mode label display for V-LINE and COMMAND modes

## Changes
- Connect to CodeEdit's `gui_input` signal to handle key input in float windows
- Use `accept_event()` to consume input events before CodeEdit processes them
- Recreate mode label instead of moving it when windows differ (avoids transient_parent error)
- Clear `user_cursor_sync` flag on key input to enable viewport sync from Neovim
- Add `is_in_float_window()` helper method to detect float window context
- Add Ctrl+[ support in command-line mode (same as Escape)
- Track visual mode type (v/V/Ctrl+V) for correct V-LINE/V
