### PR TITLE
fix: clear restored selection and preserve cursor on startup

### DIFF
--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -6,8 +6,8 @@ use godot::prelude::*;
 impl GodotNeovimPlugin {
     /// Switch to Neovim buffer for the current file
     /// Creates buffer if not exists, initializes content if new
-    /// Returns cursor position from Neovim (for existing buffers)
-    pub(super) fn switch_to_neovim_buffer(&mut self) -> Option<(i64, i64)> {
+    /// Returns (line, col, is_new) - cursor position and whether buffer was newly created
+    pub(super) fn switch_to_neovim_buffer(&mut self) -> Option<(i64, i64, bool)> {
         let Some(ref editor) = self.current_editor else {
             crate::verbose_print!("[godot-neovim] switch_to_neovim_buffer: No current editor");
             return None;
@@ -116,8 +116,8 @@ impl GodotNeovimPlugin {
                     }
                 }
 
-                // Return cursor position (convert to 0-indexed line)
-                Some((result.cursor.0 - 1, result.cursor.1))
+                // Return cursor position (convert to 0-indexed line) and is_new flag
+                Some((result.cursor.0 - 1, result.cursor.1, result.is_new))
             }
             Err(e) => {
                 godot_error!("[godot-neovim] Failed to switch buffer: {}", e);


### PR DESCRIPTION
## Summary
- Clear any restored selection when connecting to CodeEdit on startup
- Preserve Godot's cursor position for new buffers instead of using Neovim's default (file start)
- Skip spurious mouse release events on startup by checking `mouse_dragging` flag

## Root Cause
Godot's `Viewport::_post_gui_grab_click_focus()` generates synthetic mouse release events when `grab_focus()` is called during editor restore. This happens because `mouse_focus_mask` from the previous session may still have the LEFT button flag set.

## Test plan
- [ ] Open a script and drag-select some text
- [ ] Close Godot with the selection still active
- [ ] Reopen Godot
- [ ] Verify selection is cleared
- [ ] Verify cursor is at the previous position (not file start)
- [ ] Verify normal mouse drag selection still works