### PR TITLE
Fix visual mode highlight regression

### DIFF
--- a/src/plugin/visual.rs
+++ b/src/plugin/visual.rs
@@ -60,7 +60,8 @@ impl GodotNeovimPlugin {
             to_col
         );
 
-        // Update Godot selection
+        // Enable selecting and update Godot selection
+        editor.set_selecting_enabled(true);
         editor.select(from_line as i32, from_col, to_line as i32, to_col);
     }
 
@@ -114,7 +115,8 @@ impl GodotNeovimPlugin {
             to_line + 1
         );
 
-        // Update Godot selection (from start of first line to end of last line)
+        // Enable selecting and update Godot selection (from start of first line to end of last line)
+        editor.set_selecting_enabled(true);
         editor.select(from_line as i32, 0, to_line as i32, to_line_length as i32);
     }
 


### PR DESCRIPTION
## Summary

- Fix visual mode (v) and visual line mode (V) highlight not working
- Add `set_selecting_enabled(true)` before `editor.select()` calls in visual.rs

## Root Cause

Commit e10072d added `set_selecting_enabled(false)` in editor.rs to fix startup selection issue. This caused visual mode highlight to stop working because selection was disabled.

## Fix

Call `set_selecting_enabled(true)` before each `editor.select()` call in:
- `update_visual_selection()` - for character-wise visual mode (v)
- `update_visual_line_selection()` - for line-wise visual mode (V)

This ensures visual mode highlighting works while preserving the startup selection fix.

## Test Plan

- [x] Visual mode (v) shows correct selection highlight
- [x] Visual line mode (V) shows correct selection highlight
- [x] Startup selection is not incorrectly shown (regression test)