### PR TITLE
fix: Preserve indent settings (spaces/tabs) for cc/S commands

### DIFF
--- a/addons/godot-neovim/lua/godot_neovim/init.lua
+++ b/addons/godot-neovim/lua/godot_neovim/init.lua
@@ -102,11 +102,27 @@ M._attached_buffers = {}
 M._last_cursor = { 0, 0 }
 M._last_mode = ""
 
+-- Set indent options for a buffer
+-- @param bufnr number: Buffer number (0 for current buffer)
+-- @param use_spaces boolean: Use spaces instead of tabs
+-- @param indent_size number: Indent size (number of spaces or tab width)
+function M.set_indent_options(bufnr, use_spaces, indent_size)
+    if bufnr == 0 then
+        bufnr = vim.api.nvim_get_current_buf()
+    end
+
+    vim.bo[bufnr].expandtab = use_spaces
+    vim.bo[bufnr].shiftwidth = indent_size
+    vim.bo[bufnr].tabstop = indent_size
+    vim.bo[bufnr].softtabstop = indent_size
+end
+
 -- Switch to buffer by path, creating and initializing if needed
 -- @param path string: Absolute file path
 -- @param lines table|nil: Lines to initialize with (only used for new buffers)
+-- @param indent_opts table|nil: { use_spaces = bool, indent_size = number }
 -- @return table: { bufnr, tick, is_new, cursor }
-function M.switch_to_buffer(path, lines)
+function M.switch_to_buffer(path, lines, indent_opts)
     -- Find existing buffer by path
     local bufnr = vim.fn.bufnr(path)
     local is_new = (bufnr == -1)
@@ -182,6 +198,12 @@ function M.switch_to_buffer(path, lines)
         end
     else
         attached = true
+    end
+
+    -- Apply indent options if provided
+    -- This ensures Neovim uses the same indent settings as Godot
+    if indent_opts then
+        M.set_indent_options(bufnr, indent_opts.use_spaces, indent_opts.indent_size)
     end
 
     -- Get current state

--- a/src/neovim/client/execution.rs
+++ b/src/neovim/client/execution.rs
@@ -39,4 +39,29 @@ impl NeovimClient {
             }
         })
     }
+
+    /// Debug: Get current indent settings from Neovim
+    #[allow(dead_code)]
+    pub fn debug_get_indent_settings(&self) -> Result<String, String> {
+        let lua_code = r#"
+            return string.format(
+                "expandtab=%s shiftwidth=%d tabstop=%d softtabstop=%d",
+                tostring(vim.bo.expandtab),
+                vim.bo.shiftwidth,
+                vim.bo.tabstop,
+                vim.bo.softtabstop
+            )
+        "#;
+
+        match self.execute_lua_with_result(lua_code) {
+            Ok(value) => {
+                if let Some(s) = value.as_str() {
+                    Ok(s.to_string())
+                } else {
+                    Ok(format!("{:?}", value))
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
 }

--- a/src/neovim/client/mod.rs
+++ b/src/neovim/client/mod.rs
@@ -117,6 +117,15 @@ pub struct SwitchBufferResult {
     pub cursor: (i64, i64),
 }
 
+/// Indent options for Neovim buffer
+#[derive(Debug, Clone, Copy)]
+pub struct IndentOptions {
+    /// Use spaces instead of tabs
+    pub use_spaces: bool,
+    /// Indent size (number of spaces or tab width)
+    pub indent_size: i32,
+}
+
 /// Manages connection to Neovim process
 pub struct NeovimClient {
     pub(super) runtime: Runtime,

--- a/src/neovim/mod.rs
+++ b/src/neovim/mod.rs
@@ -4,7 +4,7 @@ mod handler;
 
 pub use client::NeovimClient;
 #[allow(unused_imports)]
-pub use client::SwitchBufferResult;
+pub use client::{IndentOptions, SwitchBufferResult};
 #[allow(unused_imports)]
 pub use events::{ParseError, RedrawEvent};
 pub use handler::{BufEvent, NeovimHandler, NeovimState};

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -258,6 +258,12 @@ pub fn on_settings_changed(settings: &Gd<EditorSettings>) {
         let value = settings.get_setting(SETTING_NEOVIM_PATH);
         if let Ok(path) = value.try_to::<GString>() {
             let path_str = path.to_string();
+
+            // Skip validation if path is empty (will use PATH to find nvim)
+            if path_str.is_empty() {
+                return;
+            }
+
             let result = validate_neovim_path(&path_str);
 
             match &result {


### PR DESCRIPTION
## Summary

- Fix cc/S commands defaulting to tabs instead of respecting Godot's indent settings
- Read indent settings directly from EditorSettings instead of CodeEdit (CodeEdit may have stale values when `settings_changed` signal fires)
- Skip Neovim path validation when path is empty (uses PATH lookup)

Fixes #30

## Changes

- Add `IndentOptions` struct to pass indent settings to Neovim
- Add `set_indent_options` Lua function to configure buffer indent
- Apply indent settings AFTER filetype detection to prevent override
- Read from `text_editor/behavior/indent/type` and `text_editor/behavior/indent/size` directly

## Test plan

- [x] Test with tab indent mode
- [x] Test cc command with spaces
- [x] Test settings change detection
- [x] Test different indent sizes (2 spaces, 4 spaces)
- [x] Test multiple file switching
- [x] Test nested indentation
- [x] Test empty line behavior
- [x] Test S command (substitute line)