### PR TITLE
Update Godot compatibility to 4.4+

### DIFF
--- a/addons/godot-neovim/godot-neovim.gdextension
+++ b/addons/godot-neovim/godot-neovim.gdextension
@@ -1,7 +1,6 @@
 [configuration]
 entry_symbol = "gdext_rust_init"
-compatibility_minimum = 4.2
-compatibility_maximum = 4.5
+compatibility_minimum = 4.4
 reloadable = true
 
 [libraries]


### PR DESCRIPTION
## Summary

Update gdextension compatibility settings to match godot-rust 0.4.5.

## Changes

- Set `compatibility_minimum` to 4.4 (required by godot-rust 0.4.5)
- Remove `compatibility_maximum` (no upper limit needed, allows future Godot versions)

## Notes

godot-rust 0.4.5 targets Godot 4.4+, so the minimum supported version is updated accordingly.