### PR TITLE
fix: c/d/y operators with text objects and registers

### DIFF
--- a/src/plugin/input/pending.rs
+++ b/src/plugin/input/pending.rs
@@ -259,12 +259,16 @@ impl GodotNeovimPlugin {
         }
 
         // Get the character
-        // Valid registers: a-z (named), + and * (clipboard), _ (black hole), 0 (yank)
+        // Valid registers: a-z (named), " (unnamed), + and * (clipboard), _ (black hole), 0 (yank)
         let unicode = key_event.get_unicode();
         if unicode > 0 {
             if let Some(c) = char::from_u32(unicode) {
-                let is_valid_register =
-                    c.is_ascii_lowercase() || c == '+' || c == '*' || c == '_' || c == '0';
+                let is_valid_register = c.is_ascii_lowercase()
+                    || c == '"'
+                    || c == '+'
+                    || c == '*'
+                    || c == '_'
+                    || c == '0';
                 if is_valid_register {
                     self.selected_register = Some(c);
                     crate::verbose_print!("[godot-neovim] \"{}: Register selected", c);


### PR DESCRIPTION
## Summary

- Fix operator + text object commands like `ci(`, `ci"`, `ci'`, `` ci` `` to work correctly
- Support register-prefixed text object operations (`"adi(`, `"ayi(`, `"aci(`)
- Fix visual mode text object selection (`vi"`, `va'`, `` vi` ``)

## Changes

### normal.rs
- Remove local `c` operator interception, send directly to Neovim for proper operator-pending mode
- Add register-aware `cc` handling (e.g., `"acc`)
- Add register + operator + motion/text object handling
- Skip register selection and mark jump in operator-pending and visual modes for `"`, `'`, `` ` ``

### pending.rs
- Add unnamed register (`"`) to valid register list (fixes `""p`)

## Test plan

- [x] `ci(`, `ci"`, `ci'`, `` ci` `` - change inside various text objects
- [x] `di(`, `di"`, `di'`, `` di` `` - delete inside various text objects
- [x] `vi"`, `va'`, `` vi` `` - visual select text objects
- [x] `"adi(`, `"ayi(`, `"aci(` - register-prefixed operations
- [x] `""p` - paste from unnamed register
- [x] `>i{`, `<i{`, `>i'` - indent/unindent with text objects
- [x] `'a`, `` `a `` - mark jump (regression test)
- [x] `cc`, `C`, `3cc` - change line (regression test)