### PR TITLE
feat: add macro recording indicator to status bar

### DIFF
--- a/src/plugin/editor.rs
+++ b/src/plugin/editor.rs
@@ -117,10 +117,13 @@ impl GodotNeovimPlugin {
             // Label was freed, clear and create a new one
             if label_field_is_shader {
                 self.shader_mode_label = None;
+                self.shader_recording_label = None;
             } else {
                 self.mode_label = None;
+                self.recording_label = None;
             }
             self.create_mode_label();
+            self.create_recording_label();
             return;
         }
 
@@ -168,10 +171,19 @@ impl GodotNeovimPlugin {
                             if let Some(mut old_label) = self.shader_mode_label.take() {
                                 old_label.queue_free();
                             }
-                        } else if let Some(mut old_label) = self.mode_label.take() {
-                            old_label.queue_free();
+                            if let Some(mut old_label) = self.shader_recording_label.take() {
+                                old_label.queue_free();
+                            }
+                        } else {
+                            if let Some(mut old_label) = self.mode_label.take() {
+                                old_label.queue_free();
+                            }
+                            if let Some(mut old_label) = self.recording_label.take() {
+                                old_label.queue_free();
+                            }
                         }
                         self.create_mode_label();
+                        self.create_recording_label();
                         return;
                     }
 
@@ -191,7 +203,7 @@ impl GodotNeovimPlugin {
     /// Uses: ScriptEditor.get_current_editor() -> ScriptEditorBase.get_base_editor() -> CodeEdit
     fn get_script_editor_code_edit_via_api(&self) -> Option<Gd<CodeEdit>> {
         let editor = EditorInterface::singleton();
-        let mut script_editor = editor.get_script_editor()?;
+        let script_editor = editor.get_script_editor()?;
 
         // Use public API: get_current_editor() returns ScriptEditorBase
         let current_editor: Gd<ScriptEditorBase> = script_editor.get_current_editor()?;

--- a/src/plugin/macros.rs
+++ b/src/plugin/macros.rs
@@ -7,6 +7,7 @@ impl GodotNeovimPlugin {
     pub(super) fn start_macro_recording(&mut self, register: char) {
         self.recording_macro = Some(register);
         self.macro_buffer.clear();
+        self.update_recording_label(Some(register));
         crate::verbose_print!("[godot-neovim] q{}: Started recording macro", register);
     }
 
@@ -14,6 +15,7 @@ impl GodotNeovimPlugin {
     pub(super) fn stop_macro_recording(&mut self) {
         if let Some(register) = self.recording_macro.take() {
             let keys = std::mem::take(&mut self.macro_buffer);
+            self.update_recording_label(None);
             if !keys.is_empty() {
                 self.macros.insert(register, keys.clone());
                 crate::verbose_print!(

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -129,6 +129,12 @@ pub struct GodotNeovimPlugin {
     /// Separate mode label for ShaderEditor (independent from ScriptEditor)
     #[init(val = None)]
     shader_mode_label: Option<Gd<Label>>,
+    /// Recording indicator label for ScriptEditor
+    #[init(val = None)]
+    recording_label: Option<Gd<Label>>,
+    /// Separate recording indicator label for ShaderEditor
+    #[init(val = None)]
+    shader_recording_label: Option<Gd<Label>>,
     #[init(val = None)]
     current_editor: Option<Gd<CodeEdit>>,
     /// Type of the current editor (Script, Shader, Unknown)
@@ -433,8 +439,9 @@ impl IEditorPlugin for GodotNeovimPlugin {
             crate::verbose_print!("[godot-neovim] LSP disabled (use_thread=false)");
         }
 
-        // Create mode indicator label
+        // Create mode indicator label and recording indicator
         self.create_mode_label();
+        self.create_recording_label();
 
         // Connect to script editor signals
         self.connect_script_editor_signals();


### PR DESCRIPTION
## Summary

- マクロ記録中にステータスバーに `recording @x` を赤字で表示
- ScriptEditor と ShaderEditor の両方に対応

## Changes

- `mod.rs`: `recording_label` / `shader_recording_label` フィールド追加
- `ui.rs`: `create_recording_label()` / `update_recording_label()` 追加
- `macros.rs`: 記録開始/終了時に UI 更新
- `editor.rs`: ラベル再作成時に recording_label も処理

## Test plan

- [x] `qx` でマクロ記録開始 → `recording @x` 表示（赤字）
- [x] `q` で記録終了 → 表示消える
- [x] `@x` で再生 → 動作確認
- [x] ShaderEditor でも同様に動作
- [x] `@@` で最後に再生したマクロがリプレイされる