### PR TITLE
Fix: macro playback (@) on German QWERTZ keyboards

### DIFF
--- a/src/plugin/input/normal.rs
+++ b/src/plugin/input/normal.rs
@@ -579,9 +579,11 @@ impl GodotNeovimPlugin {
         }
 
         // Handle 'q' for macro recording (start/stop) - but not after 'g' (that's gq for format)
+        // Also skip if Alt is pressed (AltGr+Q = '@' on German keyboards)
         if keycode == Key::Q
             && !key_event.is_shift_pressed()
             && !key_event.is_ctrl_pressed()
+            && !key_event.is_alt_pressed()
             && self.last_key != "g"
         {
             if self.recording_macro.is_some() {


### PR DESCRIPTION
## Summary

Fix macro playback (`@`) not working on German QWERTZ keyboards where `@` is produced by pressing AltGr+Q.

## Problem

On German keyboards:
- `@` is input via `AltGr + Q` (right Alt + Q)
- The `q` key handler was intercepting this input because it only checked for Ctrl and Shift modifiers
- Result: pressing `@` would start macro recording instead of playback

## Solution

Added `!key_event.is_alt_pressed()` check to the `q` key handler so that AltGr combinations pass through to the `@` unicode character handler.

## Test plan

- [ ] On German QWERTZ keyboard: press `qa` to start recording
- [ ] Press `q` to stop recording  
- [ ] Press `@a` (AltGr+Q, then a) to replay the macro
- [ ] Verify macro plays back correctly