### PR TITLE
fix: use Input::singleton() to detect AltGr for German keyboards

### DIFF
--- a/src/plugin/input/normal.rs
+++ b/src/plugin/input/normal.rs
@@ -4,6 +4,7 @@
 //! including g-prefix commands, [/] bracket commands, z-commands, etc.
 
 use super::super::GodotNeovimPlugin;
+use godot::classes::Input;
 use godot::global::Key;
 use godot::prelude::*;
 
@@ -579,11 +580,15 @@ impl GodotNeovimPlugin {
         }
 
         // Handle 'q' for macro recording (start/stop) - but not after 'g' (that's gq for format)
-        // Also skip if Alt is pressed (AltGr+Q = '@' on German keyboards)
+        // Also skip if AltGr is pressed (Ctrl+Alt on German keyboards for '@')
+        // Note: Use Input::singleton() to check actual key state because AltGr sends
+        // separate Ctrl and Alt events, and key_event modifiers may not be set correctly
+        let input = Input::singleton();
+        let is_altgr_held = input.is_key_pressed(Key::CTRL) && input.is_key_pressed(Key::ALT);
         if keycode == Key::Q
             && !key_event.is_shift_pressed()
             && !key_event.is_ctrl_pressed()
-            && !key_event.is_alt_pressed()
+            && !is_altgr_held
             && self.last_key != "g"
         {
             if self.recording_macro.is_some() {


### PR DESCRIPTION
## Summary

This is a follow-up fix for the German keyboard AltGr issue discussed in #45.

The previous fix (v0.9.19, PR #49) checked `key_event.is_alt_pressed()`, but on German keyboards, AltGr sends separate Ctrl and Alt key events, and the modifier flags may not be set correctly on the subsequent Q key event.

## Changes

- Use `Input::singleton().is_key_pressed()` to check the actual state of Ctrl and Alt keys
- This correctly detects AltGr (Ctrl+Alt) being held when Q is pressed

```rust
let input = Input::singleton();
let is_altgr_held = input.is_key_pressed(Key::CTRL) && input.is_key_pressed(Key::ALT);
```

## Compatibility

This fix is safe for all keyboard layouts:
- Only affects the case when both Ctrl AND Alt are pressed simultaneously
- US, JP, and other layouts that don't use AltGr+Q for `@` are unaffected
- Ctrl+Alt+Q is not a standard Vim command

## Test plan

- [ ] German QWERTZ: `@a` plays macro (AltGr+Q followed by register)
- [ ] JP layout: `q` macro recording works normally
- [ ] US layout: `q` macro recording works normally

Fixes #45