### PR TITLE
fix: mark GDExtension libraries as editor-only

### DIFF
--- a/addons/godot-neovim/godot-neovim.gdextension
+++ b/addons/godot-neovim/godot-neovim.gdextension
@@ -4,13 +4,13 @@ compatibility_minimum = 4.4
 reloadable = true
 
 [libraries]
-linux.debug.x86_64 = "res://addons/godot-neovim/bin/linux/libgodot_neovim.so"
-linux.release.x86_64 = "res://addons/godot-neovim/bin/linux/libgodot_neovim.so"
-linux.debug.arm64 = "res://addons/godot-neovim/bin/linux-arm64/libgodot_neovim.so"
-linux.release.arm64 = "res://addons/godot-neovim/bin/linux-arm64/libgodot_neovim.so"
-windows.debug.x86_64 = "res://addons/godot-neovim/bin/windows/godot_neovim.dll"
-windows.release.x86_64 = "res://addons/godot-neovim/bin/windows/godot_neovim.dll"
-macos.debug.x86_64 = "res://addons/godot-neovim/bin/macos-x86_64/libgodot_neovim.dylib"
-macos.release.x86_64 = "res://addons/godot-neovim/bin/macos-x86_64/libgodot_neovim.dylib"
-macos.debug.arm64 = "res://addons/godot-neovim/bin/macos-arm64/libgodot_neovim.dylib"
-macos.release.arm64 = "res://addons/godot-neovim/bin/macos-arm64/libgodot_neovim.dylib"
+linux.debug.editor.x86_64 = "res://addons/godot-neovim/bin/linux/libgodot_neovim.so"
+linux.release.editor.x86_64 = "res://addons/godot-neovim/bin/linux/libgodot_neovim.so"
+linux.debug.editor.arm64 = "res://addons/godot-neovim/bin/linux-arm64/libgodot_neovim.so"
+linux.release.editor.arm64 = "res://addons/godot-neovim/bin/linux-arm64/libgodot_neovim.so"
+windows.debug.editor.x86_64 = "res://addons/godot-neovim/bin/windows/godot_neovim.dll"
+windows.release.editor.x86_64 = "res://addons/godot-neovim/bin/windows/godot_neovim.dll"
+macos.debug.editor.x86_64 = "res://addons/godot-neovim/bin/macos-x86_64/libgodot_neovim.dylib"
+macos.release.editor.x86_64 = "res://addons/godot-neovim/bin/macos-x86_64/libgodot_neovim.dylib"
+macos.debug.editor.arm64 = "res://addons/godot-neovim/bin/macos-arm64/libgodot_neovim.dylib"
+macos.release.editor.arm64 = "res://addons/godot-neovim/bin/macos-arm64/libgodot_neovim.dylib"


### PR DESCRIPTION
## Summary

Add `.editor` feature tag to all library entries in the `.gdextension` file to prevent them from being included in game exports.

## Problem

When exporting a game that includes this addon, errors occur because the export process tries to include the GDExtension libraries which are editor-only.

## Solution

Mark all libraries with the `editor` feature tag:

```ini
[libraries]
linux.debug.editor.x86_64 = "res://addons/godot-neovim/bin/linux/libgodot_neovim.so"
windows.debug.editor.x86_64 = "res://addons/godot-neovim/bin/windows/godot_neovim.dll"
...
```

Format follows [Godot documentation](https://docs.godotengine.org/en/stable/tutorials/scripting/gdextension/gdextension_file.html): `platform.build.editor.architecture`

## Test plan

- [ ] Export a game project that includes this addon
- [ ] Verify no errors related to missing GDExtension libraries
- [ ] Verify the plugin still works in the editor