### PR TITLE
feat: add toggle comment passthrough (Ctrl+/ / Cmd+/)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Once the plugin is enabled:
 | `gu{motion}` | Convert to lowercase |
 | `gU{motion}` | Convert to uppercase |
 | `g~{motion}` | Toggle case |
+| `Ctrl+/` | Toggle comment (uses Godot's native comment toggle) |
 | `ga` | Display ASCII/Unicode of char under cursor |
 | `gqq` | Format current line |
 
@@ -483,6 +484,14 @@ Insert mode uses Godot's native input system to support auto-completion and othe
 | Neovim config | `init.lua` and plugins are not loaded by default (`neovim_clean = true`). Can be enabled but may cause compatibility issues with some plugins (e.g., copilot.vim, lexima.vim). |
 | `K` for signals | Signal documentation lookup not supported (class/method/property/constant only) |
 | `[m`/`]m` for GDScript | Method jump commands require Neovim treesitter or language support. GDScript is not recognized by Neovim. |
+
+### Toggle Comment (`Ctrl+/`)
+
+`Ctrl+/` (`Cmd+/` on macOS) toggles comments using Godot's native CodeEdit feature. Since this is a Godot passthrough (not a Neovim command), the following limitations apply:
+
+- **Macro recording**: `Ctrl+/` is not recorded during macro recording (`q{a-z}`)
+- **Dot repeat**: `.` does not repeat `Ctrl+/`
+- **Undo**: Uses Godot's undo system, not Neovim's `u`
 
 ### Known Issues
 

--- a/src/plugin/actions.rs
+++ b/src/plugin/actions.rs
@@ -338,6 +338,26 @@ impl GodotNeovimPlugin {
     }
 
     // =========================================================================
+    // Toggle comment (Ctrl+/)
+    // =========================================================================
+
+    /// Toggle comment on current line or visual selection (Ctrl+/)
+    /// Passes the key through to Godot's CodeEdit for native comment toggling,
+    /// then syncs the changed buffer to Neovim via deferred call.
+    pub(super) fn action_toggle_comment_impl(&mut self) {
+        // If in visual mode, exit visual mode after comment toggle
+        if Self::is_visual_mode(&self.current_mode) {
+            self.send_keys("<Esc>");
+        }
+
+        // Schedule deferred buffer sync (Godot hasn't processed the key yet)
+        self.base_mut()
+            .call_deferred("sync_buffer_after_toggle_comment", &[]);
+
+        // Do NOT call set_input_as_handled() — let Godot's CodeEdit handle Ctrl+/
+    }
+
+    // =========================================================================
     // Documentation
     // =========================================================================
 

--- a/src/plugin/input/normal.rs
+++ b/src/plugin/input/normal.rs
@@ -90,6 +90,13 @@ impl GodotNeovimPlugin {
             return;
         }
 
+        // Handle Ctrl+/ (Cmd+/ on macOS) for toggle comment (pass through to Godot)
+        if key_event.is_command_or_control_pressed() && keycode == Key::SLASH {
+            self.action_toggle_comment_impl();
+            // Do NOT call set_input_as_handled() — let Godot handle the key
+            return;
+        }
+
         // Handle Ctrl+O for jump back in jump list
         if key_event.is_ctrl_pressed() && keycode == Key::O {
             self.action_jump_back_impl();

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -911,6 +911,16 @@ impl GodotNeovimPlugin {
         self.sync_cursor_to_neovim();
     }
 
+    /// Sync buffer to Neovim after Ctrl+/ comment toggle
+    /// Called via call_deferred to ensure Godot has already processed the key
+    #[func]
+    fn sync_buffer_after_toggle_comment(&mut self) {
+        self.sync_buffer_to_neovim_keep_undo();
+        self.sync_cursor_to_neovim();
+
+        crate::verbose_print!("[godot-neovim] Synced buffer after toggle comment");
+    }
+
     /// Sync mouse selection to Neovim on mouse release
     /// If there's a selection (drag), enter visual mode and sync selection range
     /// If no selection (click), just sync cursor position
@@ -1659,6 +1669,12 @@ impl GodotNeovimPlugin {
     #[func]
     fn action_show_file_info(&mut self) {
         self.action_show_file_info_impl();
+    }
+
+    /// Toggle comment (Ctrl+/)
+    #[func]
+    fn action_toggle_comment(&mut self) {
+        self.action_toggle_comment_impl();
     }
 
     /// Open forward search mode (/)


### PR DESCRIPTION
## Summary

- Pass Ctrl+/ (Cmd+/ on macOS) through to Godot's native CodeEdit for comment toggling
- Use `is_command_or_control_pressed()` for cross-platform key detection
- Sync buffer changes to Neovim via deferred call after Godot processes the key
- In visual mode, toggle comments on selection then return to normal mode
- Add GDScript-callable API (`action_toggle_comment`)
- Document the command and its limitations in README

Closes #58

## Test plan

- [ ] Press Ctrl+/ (macOS: Cmd+/) in normal mode to toggle comment on current line
- [ ] Select lines in visual mode, then press Ctrl+/ to toggle comments on selection
- [ ] Verify Neovim buffer is synced after comment toggle
- [ ] Verify Ctrl+/ works on Windows/Linux and Cmd+/ works on macOS