### PR TITLE
fix: cursor jumps to next line after change/delete operations

### DIFF
--- a/src/plugin/commands/file_ops.rs
+++ b/src/plugin/commands/file_ops.rs
@@ -321,6 +321,10 @@ impl GodotNeovimPlugin {
                             let char_col = Self::byte_col_to_char_col(&line_text, col as i32);
                             code_edit.set_caret_line(line);
                             code_edit.set_caret_column(char_col);
+                            // Update last_synced_cursor so the deferred caret_changed (emitted
+                            // via call_deferred by TextEdit) matches and is skipped in
+                            // on_caret_changed, preventing a redundant sync back to Neovim.
+                            self.last_synced_cursor = (line as i64, char_col as i64);
                             crate::verbose_print!(
                                 "[godot-neovim] :e! - Set cursor to line={}, col={} (byte_col={})",
                                 line,

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -324,6 +324,13 @@ pub struct GodotNeovimPlugin {
     /// This flag prevents incorrect cursor positioning after :q and reopen
     #[init(val = false)]
     skip_grid_cursor_after_switch: bool,
+    /// Flag to sync cursor at insert mode entry even across frame boundaries
+    /// Set when entering insert mode without a viewport_change in the same frame
+    /// (e.g., cw: mode_change arrives Frame N, buf_lines+viewport arrive Frame N+1).
+    /// Without this, the is_insert && !entering_insert guard skips the cursor sync in N+1,
+    /// leaving the cursor at Godot's auto-moved position instead of the Neovim position.
+    #[init(val = false)]
+    pending_insert_cursor_sync: bool,
     /// Flag to apply cursor correction after Ctrl+B
     /// With ext_multigrid, Ctrl+B at end of file reports wrong viewport height,
     /// causing cursor to barely move. This flag triggers correction after viewport sync.
@@ -2031,6 +2038,7 @@ impl GodotNeovimPlugin {
         self.script_neovim = None;
         self.shader_neovim = None;
 
+        self.pending_insert_cursor_sync = false;
         self.plugin_active = false;
         crate::verbose_print!("[godot-neovim] Plugin deactivated");
     }

--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -962,6 +962,15 @@ impl GodotNeovimPlugin {
                 self.clear_last_key();
             }
 
+            // If entering insert mode but no viewport_change in this frame, set a flag so
+            // the NEXT frame's viewport_change still syncs the cursor once (handles cw, ciw,
+            // etc. where the mode_change and buf_lines+viewport arrive in separate frames).
+            // When entering_insert and viewport_change arrive together, the else branch in
+            // viewport_change processing will clear the flag itself.
+            if entering_insert && viewport_change.is_none() {
+                self.pending_insert_cursor_sync = true;
+            }
+
             // Visual selection update (only when no viewport_change)
             // When viewport_change is present, we must update visual selection AFTER
             // sync_cursor_from_grid, otherwise the cursor sync will clear the selection
@@ -1005,11 +1014,12 @@ impl GodotNeovimPlugin {
                 if let Some((ref mode, _)) = state_from_redraw {
                     self.update_mode_display_with_cursor(mode, Some(display_cursor));
                 }
-            } else if is_insert && !entering_insert {
+            } else if is_insert && !entering_insert && !self.pending_insert_cursor_sync {
                 // Skip cursor sync while in insert mode (after initial entry)
                 // Godot controls cursor during insert mode, syncing would override user's position
                 // and cause typed characters to appear in reverse order
-                // Only entering_insert allows cursor sync to position cursor on the new line (o/O commands)
+                // Only entering_insert (or pending_insert_cursor_sync for cross-frame entry like cw)
+                // allows cursor sync to position cursor at the operation's insertion point.
                 crate::verbose_print!(
                     "[godot-neovim] Skipping cursor sync (in insert mode): cursor=({}, {})",
                     curline,
@@ -1025,6 +1035,8 @@ impl GodotNeovimPlugin {
                     self.update_mode_display_with_cursor(mode, Some(display_cursor));
                 }
             } else {
+                // Clear pending_insert_cursor_sync since we're about to sync the cursor
+                self.pending_insert_cursor_sync = false;
                 // Set cursor FIRST - this may trigger Godot's auto-scroll
                 self.sync_cursor_from_grid(cursor);
 
@@ -1183,6 +1195,13 @@ impl GodotNeovimPlugin {
         // Set flag to prevent echo back to Neovim
         self.sync_manager.begin_nvim_change();
 
+        // Prevent caret_changed from syncing Godot's cursor back to Neovim while
+        // we are modifying the buffer. Buffer edits (remove_line_at, insert_line_at,
+        // set_text) cause Godot to reposition the caret automatically, and without
+        // this guard that stale position would be sent to Neovim, overriding the
+        // correct post-change cursor that Neovim sends separately (e.g. cc → col 0).
+        self.syncing_from_grid = true;
+
         let line_count = editor.get_line_count() as i64;
         let first = change.first_line.max(0) as i32;
         let last = if change.last_line < 0 {
@@ -1200,7 +1219,13 @@ impl GodotNeovimPlugin {
             // Full buffer replacement: use set_text for reliability
             let new_text = change.new_lines.join("\n");
             editor.set_text(&new_text);
+            // Record Godot's caret after the edit so the deferred caret_changed matches.
+            // See comment before end_nvim_change() below for details.
+            let after_line = editor.get_caret_line() as i64;
+            let after_col = editor.get_caret_column() as i64;
+            self.last_synced_cursor = (after_line, after_col);
             self.sync_manager.end_nvim_change();
+            self.syncing_from_grid = false;
             return;
         }
 
@@ -1265,7 +1290,17 @@ impl GodotNeovimPlugin {
             }
         }
 
+        // Record Godot's caret position right after the buffer edit so that the deferred
+        // caret_changed (Godot's TextEdit queues the signal via call_deferred) fires with
+        // last_synced_cursor already matching the transient caret. Without this, on_caret_changed
+        // would call sync_cursor_to_neovim() with Godot's auto-moved caret, overriding the
+        // correct cursor that Neovim sends separately via win_viewport → sync_cursor_from_grid().
+        let after_line = editor.get_caret_line() as i64;
+        let after_col = editor.get_caret_column() as i64;
+        self.last_synced_cursor = (after_line, after_col);
+
         self.sync_manager.end_nvim_change();
+        self.syncing_from_grid = false;
     }
 
     /// Convert byte column to character column for a given line


### PR DESCRIPTION
Root cause 1 – deferred caret_changed after buffer edits (cc, C, D, s): Godot's TextEdit queues caret_changed via call_deferred, so the signal fires at frame end after syncing_from_grid is already reset. Without recording the post-edit caret position in last_synced_cursor, on_caret_changed would call sync_cursor_to_neovim() with Godot's auto-moved caret, overriding the correct cursor position sent by Neovim separately.
Fix: record last_synced_cursor after each apply_nvim_change() call (including the full-replacement early-return path) and after cmd_reload() (:e!).

Root cause 2 – cross-frame insert entry cursor sync (cw, ciw, etc.): When entering insert mode, Neovim sometimes sends the mode_change event in one process() frame and the buf_lines_event + win_viewport in the next frame. In the second frame entering_insert=false and is_insert=true, which triggered the "skip cursor sync in insert mode" guard, leaving the cursor at Godot's auto-moved position (typically the next line) instead of the correct position. Fix: introduce pending_insert_cursor_sync flag. Set when entering_insert but no viewport_change in that frame; cleared after the first subsequent viewport_change syncs the cursor.

Fixes #60