### PR TITLE
feat: add Neovim Keymaps settings panel for keybinding customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ godot-neovim integrates Neovim into Godot's script editor, allowing you to use t
 | | `:sort`, `:t`, `:m` | ✅ | ❌ |
 | | `:bn`, `:bp`, `:bd`, `:ls` | ✅ | ❌ |
 | | `ZZ`, `ZQ`, `@:`, `Ctrl+G` | ✅ | ❌ |
-| **Other** | Custom key mappings | ❌ | ✅ |
+| **Other** | Custom key mappings | ✅ (Neovim Keymaps panel) | ✅ |
 
 \* `[m`/`]m` requires Neovim's treesitter or language-specific support. GDScript is not recognized by Neovim, so these commands may not work as expected.
 
@@ -172,6 +172,31 @@ The `gd` command uses Godot's built-in LSP server for accurate navigation. To en
 3. Enable **Use Thread** option
 
 When this setting is disabled, `gd` will show a message prompting you to enable it.
+
+### Custom Key Mappings
+
+The **Neovim Keymaps** dock panel allows you to customize key bindings without recompiling the plugin. The panel appears in the right dock area (alongside Inspector, Node, etc.) when the plugin is active.
+
+**Features:**
+- View all current key bindings for Normal and Visual modes
+- Edit key bindings by double-clicking the Key column
+- Delete bindings with the `Delete` key
+- Reset to defaults with the **Reset** button
+- Import keymaps from Neovim with the **Import from Neovim** button (requires `neovim_clean = false` for user keymaps)
+
+**Key format** follows Neovim notation:
+- Single characters: `a`, `A`, `/`, `$`, etc.
+- Control combinations: `<C-a>`, `<C-f>`, etc.
+- Special keys: `<CR>`, `<Esc>`, `<Tab>`, `<BS>`, etc.
+- Key sequences: `gd`, `zo`, `ZZ`, `[[`, etc.
+
+**Validation:**
+- Only valid Neovim key notation is accepted
+- Duplicate keys within the same mode are rejected
+
+Custom mappings are persisted in `Editor Settings` under `godot_neovim/custom_keymaps` and survive editor restarts. Custom overrides are marked with `*` in the panel.
+
+> **Note**: Not all keys are customizable through the panel. Keys handled internally by the Neovim state machine (count prefixes, pending operations like `f`/`t`/`r`, register selection `"`, macro recording `q`/`@`, and operators `>`/`<`) are managed by the plugin's Rust backend.
 
 ## Exporting Projects
 

--- a/addons/godot-neovim/input/godot_neovim_input.gd
+++ b/addons/godot-neovim/input/godot_neovim_input.gd
@@ -1,0 +1,143 @@
+## GDScript input handler for GodotNeovim.
+##
+## Dispatches resolved key sequences to plugin action methods based on keymaps.
+## Register this handler with the plugin to enable GDScript-based key dispatch,
+## which allows customizing key bindings without recompiling the GDExtension.
+##
+## Usage (automatic):
+##   The plugin automatically instantiates and sets up this handler on startup.
+##
+## Usage (manual):
+##   var input_handler = GodotNeovimInput.new()
+##   input_handler.setup(plugin)
+class_name GodotNeovimInput
+extends RefCounted
+
+## Reference to the GodotNeovimPlugin instance.
+var plugin: Object
+
+## Mode-specific keymaps: { mode_string: { key_string: action_or_callable } }
+## Modes: "n" (normal), "v"/"V"/"\x16" (visual variants)
+var keymaps: Dictionary = {}
+
+## Visual mode keys (all visual variants share the same keymap)
+const VISUAL_MODES: PackedStringArray = ["v", "V", "\u0016"]
+
+
+func _init() -> void:
+	pass
+
+
+## Initialize the input handler with a plugin reference.
+## Call this after instantiation (ClassDB.instantiate cannot pass constructor args).
+func setup(p_plugin: Object) -> void:
+	plugin = p_plugin
+
+	# Load default keymaps
+	keymaps["n"] = GodotNeovimDefaultKeymaps.get_normal_keymap()
+	var visual_map := GodotNeovimDefaultKeymaps.get_visual_keymap()
+	for mode in VISUAL_MODES:
+		keymaps[mode] = visual_map.duplicate()
+
+	# Load custom keymaps from EditorSettings (godot_neovim/custom_keymaps)
+	_load_custom_keymaps_from_settings()
+
+	# Note: input handler registration is done by plugin.gd after setup() returns,
+	# to avoid re-entrant borrow issues with &mut self.
+
+
+
+## Dispatch callback, invoked via call_deferred from Rust input() to avoid re-entrant borrow.
+## Rust handles mouse, key filtering, mode routing, and key resolution in input().
+## This method only does keymap lookup and action dispatch.
+## [param resolved_key] Key string in Neovim notation (e.g., "gd", "<C-f>", "ZZ")
+## [param mode] Current vim mode ("n", "v", "V", etc.)
+func _on_dispatch(resolved_key: String, mode: String) -> void:
+	# Look up action in keymap
+	var keymap: Dictionary = _get_keymap_for_mode(mode)
+	var action = keymap.get(resolved_key, "")
+
+	# All plugin calls use call_deferred to avoid re-entrant &mut self borrow.
+	# _dispatch_key_to_gdscript holds &mut self while calling this method,
+	# so direct plugin calls would cause a borrow conflict in godot-rs.
+	if action is Callable:
+		action.call_deferred()
+	elif action is String and action != "":
+		plugin.call_deferred(action)
+	else:
+		# Key not in keymap - send directly to Neovim
+		plugin.call_deferred(&"action_send_keys", resolved_key)
+
+
+## Get the keymap for a given mode.
+func _get_keymap_for_mode(mode: String) -> Dictionary:
+	if keymaps.has(mode):
+		return keymaps[mode]
+	# Fallback to normal mode keymap
+	return keymaps.get("n", {})
+
+
+
+## Apply keymap changes from the keymap editor.
+## Called by GodotNeovimKeymapEditor when changes are saved.
+## [param p_changes] Dictionary with format: { "n": { "set": {}, "removed": [] }, "v": ... }
+func apply_keymap_changes(p_changes: Dictionary) -> void:
+	# Rebuild keymaps from defaults
+	keymaps["n"] = GodotNeovimDefaultKeymaps.get_normal_keymap()
+	var visual_map := GodotNeovimDefaultKeymaps.get_visual_keymap()
+	for mode in VISUAL_MODES:
+		keymaps[mode] = visual_map.duplicate()
+
+	# Apply changes (set overrides, remove bindings)
+	for mode_key in p_changes:
+		if not keymaps.has(mode_key):
+			# Apply to all visual mode variants if mode_key is "v"
+			if mode_key == "v":
+				for vm in VISUAL_MODES:
+					_apply_mode_changes(vm, p_changes[mode_key])
+			continue
+		_apply_mode_changes(mode_key, p_changes[mode_key])
+
+
+
+## Apply changes for a single mode.
+func _apply_mode_changes(mode: String, mode_changes: Dictionary) -> void:
+	if not keymaps.has(mode):
+		return
+	var removed: Array = mode_changes.get("removed", [])
+	for key in removed:
+		keymaps[mode].erase(key)
+	var set_dict: Dictionary = mode_changes.get("set", {})
+	for key in set_dict:
+		keymaps[mode][key] = set_dict[key]
+
+
+## Load custom keymaps from EditorSettings (godot_neovim/custom_keymaps).
+## Same format as keymap_editor.gd saves.
+func _load_custom_keymaps_from_settings() -> void:
+	var settings := EditorInterface.get_editor_settings()
+	if not settings:
+		return
+	var settings_key := "godot_neovim/custom_keymaps"
+	if not settings.has_setting(settings_key):
+		return
+	var json_str: String = settings.get_setting(settings_key)
+	if json_str.is_empty():
+		return
+	var json := JSON.new()
+	if json.parse(json_str) != OK:
+		push_warning("[godot-neovim] Failed to parse custom_keymaps from EditorSettings")
+		return
+	var data: Dictionary = json.data
+	for mode_key in data:
+		if mode_key == "v":
+			for vm in VISUAL_MODES:
+				_apply_mode_changes(vm, data[mode_key])
+		elif keymaps.has(mode_key):
+			_apply_mode_changes(mode_key, data[mode_key])
+
+
+## Disconnect this input handler from the plugin.
+func disconnect_handler() -> void:
+	if plugin:
+		plugin.clear_input_handler()

--- a/addons/godot-neovim/input/keymap_editor.gd
+++ b/addons/godot-neovim/input/keymap_editor.gd
@@ -1,0 +1,467 @@
+## Keymap editor dock panel for GodotNeovim.
+##
+## Provides a GUI to view and customize key bindings.
+## Changes are persisted to EditorSettings and applied in real-time.
+class_name GodotNeovimKeymapEditor
+extends Control
+
+const SETTINGS_KEY := "godot_neovim/custom_keymaps"
+
+var plugin: Object
+var input_handler: Object  # GodotNeovimInput instance
+
+var mode_button: OptionButton
+var reset_button: Button
+var import_button: Button
+var tree: Tree
+var status_label: Label
+
+## Current mode being displayed ("n" or "v")
+var current_display_mode: String = "n"
+
+## Tracked changes: { "n": { "set": {}, "removed": [] }, "v": { "set": {}, "removed": [] } }
+var changes: Dictionary = {}
+
+
+## Initialize the editor with plugin and input handler references.
+## Called before _ready() (before entering the scene tree).
+func setup(p_plugin: Object, p_input_handler: Object) -> void:
+	plugin = p_plugin
+	input_handler = p_input_handler
+
+
+func _ready() -> void:
+	_init_changes()
+	_build_ui()
+	_load_from_editor_settings()
+	_refresh_tree()
+
+
+func _init_changes() -> void:
+	changes = {
+		"n": {"set": {}, "removed": []},
+		"v": {"set": {}, "removed": []},
+	}
+
+
+func _build_ui() -> void:
+	var vbox := VBoxContainer.new()
+	vbox.set_anchors_preset(Control.PRESET_FULL_RECT)
+	add_child(vbox)
+
+	# Toolbar
+	var toolbar := HBoxContainer.new()
+	vbox.add_child(toolbar)
+
+	mode_button = OptionButton.new()
+	mode_button.add_item("Normal", 0)
+	mode_button.add_item("Visual", 1)
+	mode_button.item_selected.connect(_on_mode_selected)
+	toolbar.add_child(mode_button)
+
+	reset_button = Button.new()
+	reset_button.text = "Reset"
+	reset_button.pressed.connect(_on_reset_pressed)
+	toolbar.add_child(reset_button)
+
+	import_button = Button.new()
+	import_button.text = "Import from Neovim"
+	import_button.pressed.connect(_on_import_pressed)
+	toolbar.add_child(import_button)
+
+	# Tree
+	tree = Tree.new()
+	tree.columns = 3
+	tree.set_column_title(0, "Key")
+	tree.set_column_title(1, "Action")
+	tree.set_column_title(2, "")
+	tree.set_column_titles_visible(true)
+	tree.set_column_expand(0, true)
+	tree.set_column_expand(1, true)
+	tree.set_column_expand(2, false)
+	tree.set_column_custom_minimum_width(2, 30)
+	tree.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	tree.item_edited.connect(_on_tree_item_edited)
+	vbox.add_child(tree)
+
+	# Key input for tree
+	tree.gui_input.connect(_on_tree_gui_input)
+
+	# Status label
+	status_label = Label.new()
+	status_label.text = ""
+	vbox.add_child(status_label)
+
+
+func _on_mode_selected(index: int) -> void:
+	current_display_mode = "n" if index == 0 else "v"
+	_refresh_tree()
+
+
+func _on_reset_pressed() -> void:
+	changes[current_display_mode] = {"set": {}, "removed": []}
+	_save_and_apply()
+	_refresh_tree()
+	status_label.text = "Reset %s mode to defaults" % ("Normal" if current_display_mode == "n" else "Visual")
+
+
+func _on_import_pressed() -> void:
+	if not plugin or not plugin.has_method(&"get_neovim_keymaps"):
+		status_label.text = "Plugin not available"
+		return
+
+	var mode := current_display_mode
+	var nvim_maps: Dictionary = plugin.get_neovim_keymaps(mode)
+	if nvim_maps.is_empty():
+		status_label.text = "No Neovim keymaps found (Neovim not connected or --clean mode)"
+		return
+
+	# Show import dialog with Neovim keymaps
+	var dialog := AcceptDialog.new()
+	dialog.title = "Import from Neovim"
+	dialog.min_size = Vector2i(500, 400)
+
+	var vbox := VBoxContainer.new()
+	dialog.add_child(vbox)
+
+	var label := Label.new()
+	label.text = "Select keymaps to import (%s mode, %d found):" % [
+		"Normal" if mode == "n" else "Visual", nvim_maps.size()
+	]
+	vbox.add_child(label)
+
+	var import_tree := Tree.new()
+	import_tree.columns = 3
+	import_tree.set_column_title(0, "")
+	import_tree.set_column_title(1, "Key")
+	import_tree.set_column_title(2, "Mapping")
+	import_tree.set_column_titles_visible(true)
+	import_tree.set_column_expand(0, false)
+	import_tree.set_column_custom_minimum_width(0, 30)
+	import_tree.set_column_expand(1, true)
+	import_tree.set_column_expand(2, true)
+	import_tree.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	vbox.add_child(import_tree)
+
+	var root := import_tree.create_item()
+	var sorted_keys: Array = nvim_maps.keys()
+	sorted_keys.sort()
+	for key in sorted_keys:
+		var item := import_tree.create_item(root)
+		item.set_cell_mode(0, TreeItem.CELL_MODE_CHECK)
+		item.set_checked(0, false)
+		item.set_editable(0, true)
+		item.set_text(1, key)
+		item.set_text(2, nvim_maps[key])
+
+	dialog.confirmed.connect(func():
+		var mode_changes: Dictionary = changes[current_display_mode]
+		var set_dict: Dictionary = mode_changes["set"]
+		var item := root.get_first_child()
+		var count := 0
+		while item:
+			if item.is_checked(0):
+				var lhs: String = item.get_text(1)
+				var rhs: String = item.get_text(2)
+				# Import as action_send_keys mapping (sends rhs to Neovim)
+				set_dict[lhs] = "action_send_keys"
+				count += 1
+			item = item.get_next()
+		if count > 0:
+			_save_and_apply()
+			_refresh_tree()
+			status_label.text = "Imported %d keymaps from Neovim" % count
+		dialog.queue_free()
+	)
+	dialog.canceled.connect(func():
+		dialog.queue_free()
+	)
+
+	add_child(dialog)
+	dialog.popup_centered()
+
+
+func _on_tree_gui_input(event: InputEvent) -> void:
+	if event is InputEventKey and event.is_pressed() and event.keycode == KEY_DELETE:
+		var selected := tree.get_selected()
+		if selected == null or selected == tree.get_root():
+			return
+
+		var key_str: String = selected.get_text(0)
+		var is_custom: bool = selected.get_text(2) != ""
+
+		var mode_changes: Dictionary = changes[current_display_mode]
+		var set_dict: Dictionary = mode_changes["set"]
+		var removed_arr: Array = mode_changes["removed"]
+
+		if set_dict.has(key_str):
+			# Remove custom override
+			set_dict.erase(key_str)
+		else:
+			# Remove default binding
+			if key_str not in removed_arr:
+				removed_arr.append(key_str)
+
+		_save_and_apply()
+		_refresh_tree()
+		status_label.text = "Removed binding: %s" % key_str
+
+
+func _on_tree_item_edited() -> void:
+	var item := tree.get_edited()
+	if item == null:
+		return
+
+	var column := tree.get_edited_column()
+	var old_key: String = item.get_metadata(0) if item.get_metadata(0) else ""
+	var new_text: String = item.get_text(column)
+
+	if new_text.is_empty():
+		_refresh_tree()
+		return
+
+	var mode_changes: Dictionary = changes[current_display_mode]
+	var set_dict: Dictionary = mode_changes["set"]
+	var removed_arr: Array = mode_changes["removed"]
+
+	if column != 0:
+		return
+
+	# Validate key format
+	var validation_error := _validate_key(new_text)
+	if not validation_error.is_empty():
+		status_label.text = validation_error
+		_refresh_tree()
+		return
+
+	# Check for duplicate key (skip if unchanged)
+	if new_text != old_key and _is_key_duplicate(new_text, old_key):
+		status_label.text = "Key '%s' is already mapped in %s mode" % [
+			new_text, "Normal" if current_display_mode == "n" else "Visual"
+		]
+		_refresh_tree()
+		return
+
+	# Key column edited - look up action from current data
+	var default_map: Dictionary
+	if current_display_mode == "n":
+		default_map = GodotNeovimDefaultKeymaps.get_normal_keymap()
+	else:
+		default_map = GodotNeovimDefaultKeymaps.get_visual_keymap()
+
+	var action: String = set_dict.get(old_key, default_map.get(old_key, "action_send_keys"))
+
+	# If old key was a custom override, remove it
+	if set_dict.has(old_key):
+		set_dict.erase(old_key)
+	elif old_key != "" and old_key not in removed_arr:
+		# Old key was a default, mark as removed
+		removed_arr.append(old_key)
+	# Add new key -> action mapping
+	set_dict[new_text] = action
+
+	_save_and_apply()
+	_refresh_tree()
+	status_label.text = "Key changed: '%s' -> '%s'" % [old_key, new_text]
+
+
+func _refresh_tree() -> void:
+	tree.clear()
+	var root := tree.create_item()
+
+	# Build effective keymap: start with defaults, apply changes
+	var default_map: Dictionary
+	if current_display_mode == "n":
+		default_map = GodotNeovimDefaultKeymaps.get_normal_keymap()
+	else:
+		default_map = GodotNeovimDefaultKeymaps.get_visual_keymap()
+
+	var mode_changes: Dictionary = changes[current_display_mode]
+	var set_dict: Dictionary = mode_changes["set"]
+	var removed_arr: Array = mode_changes["removed"]
+
+	# Collect all keys (defaults + custom overrides)
+	var all_keys: Dictionary = {}
+
+	# Add default keys (not removed)
+	for key in default_map:
+		if key not in removed_arr:
+			var action: String = set_dict[key] if set_dict.has(key) else default_map[key]
+			var is_custom: bool = set_dict.has(key)
+			all_keys[key] = {"action": action, "custom": is_custom}
+
+	# Add custom-only keys (not in defaults)
+	for key in set_dict:
+		if not all_keys.has(key):
+			all_keys[key] = {"action": set_dict[key], "custom": true}
+
+	# Sort by key for display
+	var sorted_keys: Array = all_keys.keys()
+	sorted_keys.sort()
+
+	for key in sorted_keys:
+		var info: Dictionary = all_keys[key]
+		var item := tree.create_item(root)
+		item.set_text(0, key)
+		item.set_editable(0, true)
+		item.set_metadata(0, key)  # Store original key for edit tracking
+		item.set_text(1, _display_action_name(info["action"]))
+		item.set_editable(1, false)
+		if info["custom"]:
+			item.set_text(2, "*")
+		item.set_selectable(2, false)
+
+
+## Convert internal action name to display name.
+## e.g. "action_search_word_backward" -> "search word backward"
+static func _display_action_name(action: String) -> String:
+	var name := action
+	if name.begins_with("action_"):
+		name = name.substr(7)  # len("action_") == 7
+	return name.replace("_", " ")
+
+
+## Valid special key names in Neovim notation (inside angle brackets).
+const VALID_SPECIAL_KEYS: PackedStringArray = [
+	"Esc", "CR", "Tab", "BS", "Del", "Space",
+	"Up", "Down", "Left", "Right",
+	"Home", "End", "PageUp", "PageDown",
+	"F1", "F2", "F3", "F4", "F5", "F6",
+	"F7", "F8", "F9", "F10", "F11", "F12",
+	"Bar", "Bslash", "LT",
+]
+
+## Valid modifier prefixes.
+const VALID_MODIFIERS: PackedStringArray = ["C", "A", "S", "C-A", "C-S", "A-S", "C-A-S"]
+
+## Printable characters valid as single-key bindings.
+const VALID_SINGLE_CHARS := (
+	"abcdefghijklmnopqrstuvwxyz"
+	+ "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	+ "0123456789"
+	+ "!@#$%^&*()-_=+[]{};:'\",.<>/?\\|`~ "
+)
+
+
+## Validate a key string in Neovim notation.
+## Returns an empty string if valid, or an error message if invalid.
+static func _validate_key(key: String) -> String:
+	if key.is_empty():
+		return "Key cannot be empty"
+
+	# Special key with angle brackets: <C-a>, <CR>, <C-A-Del>, etc.
+	if key.begins_with("<") and key.ends_with(">"):
+		var inner := key.substr(1, key.length() - 2)
+		if inner.is_empty():
+			return "Invalid key: empty angle brackets"
+
+		# Check for modifier prefix: <C-x>, <A-x>, <C-A-x>, etc.
+		var last_dash := inner.rfind("-")
+		if last_dash > 0:
+			var modifier_part := inner.substr(0, last_dash)
+			var key_part := inner.substr(last_dash + 1)
+			if modifier_part not in VALID_MODIFIERS:
+				return "Invalid modifier '%s' in '%s'. Valid: %s" % [
+					modifier_part, key, ", ".join(VALID_MODIFIERS)
+				]
+			if key_part.is_empty():
+				return "Missing key after modifier in '%s'" % key
+			# Key part after modifier: single char or special key name
+			if key_part.length() == 1:
+				return ""  # e.g., <C-a>, <A-x>
+			if key_part in VALID_SPECIAL_KEYS:
+				return ""  # e.g., <C-Del>, <C-A-Tab>
+			return "Invalid key '%s' in '%s'. Expected single char or special key" % [key_part, key]
+
+		# No modifier: <CR>, <Esc>, <F1>, etc.
+		if inner in VALID_SPECIAL_KEYS:
+			return ""
+		return "Invalid special key '<%s>'. Valid: %s" % [inner, ", ".join(VALID_SPECIAL_KEYS)]
+
+	# Multi-char sequence (no angle brackets): gd, zo, ZZ, [[, etc.
+	if key.length() >= 2:
+		for i in key.length():
+			var ch := key[i]
+			if VALID_SINGLE_CHARS.find(ch) == -1:
+				return "Invalid character '%s' in key sequence '%s'" % [ch, key]
+		return ""
+
+	# Single character
+	if key.length() == 1:
+		if VALID_SINGLE_CHARS.find(key) != -1:
+			return ""
+		return "Invalid key character '%s'" % key
+
+	return "Invalid key format: '%s'" % key
+
+
+## Check if a key is already mapped in the current mode's effective keymap.
+## [param new_key] The key to check for duplicates.
+## [param old_key] The key being replaced (excluded from duplicate check).
+func _is_key_duplicate(new_key: String, old_key: String) -> bool:
+	var default_map: Dictionary
+	if current_display_mode == "n":
+		default_map = GodotNeovimDefaultKeymaps.get_normal_keymap()
+	else:
+		default_map = GodotNeovimDefaultKeymaps.get_visual_keymap()
+
+	var mode_changes: Dictionary = changes[current_display_mode]
+	var set_dict: Dictionary = mode_changes["set"]
+	var removed_arr: Array = mode_changes["removed"]
+
+	# Collect all currently active keys (excluding old_key)
+	# Default keys (not removed)
+	for key in default_map:
+		if key == old_key:
+			continue
+		if key not in removed_arr:
+			if key == new_key:
+				return true
+
+	# Custom keys
+	for key in set_dict:
+		if key == old_key:
+			continue
+		if key == new_key:
+			return true
+
+	return false
+
+
+func _save_and_apply() -> void:
+	_save_to_editor_settings()
+	if input_handler and input_handler.has_method("apply_keymap_changes"):
+		input_handler.apply_keymap_changes(changes)
+
+
+func _save_to_editor_settings() -> void:
+	var json_str := JSON.stringify(changes)
+	var settings := EditorInterface.get_editor_settings()
+	settings.set_setting(SETTINGS_KEY, json_str)
+
+
+func _load_from_editor_settings() -> void:
+	var settings := EditorInterface.get_editor_settings()
+	if not settings.has_setting(SETTINGS_KEY):
+		return
+
+	var json_str: String = settings.get_setting(SETTINGS_KEY)
+	if json_str.is_empty():
+		return
+
+	var json := JSON.new()
+	if json.parse(json_str) != OK:
+		push_warning("[godot-neovim] Failed to parse custom_keymaps from EditorSettings")
+		return
+
+	var data: Dictionary = json.data
+	# Merge loaded data into changes
+	for mode_key in data:
+		if changes.has(mode_key):
+			var loaded: Dictionary = data[mode_key]
+			changes[mode_key]["set"] = loaded.get("set", {})
+			var removed = loaded.get("removed", [])
+			if removed is Array:
+				changes[mode_key]["removed"] = removed
+			else:
+				changes[mode_key]["removed"] = []

--- a/addons/godot-neovim/plugin.gd
+++ b/addons/godot-neovim/plugin.gd
@@ -10,6 +10,11 @@ extends EditorPlugin
 ## It finds the GodotNeovimPlugin instance (registered in the "godot_neovim" group)
 ## and calls set_plugin_active(true/false) to initialize or clean up the plugin.
 
+## GDScript input handler for customizable keybindings
+var _input_handler: GodotNeovimInput
+## Keymap editor dock panel
+var _keymap_editor: GodotNeovimKeymapEditor
+
 
 func _enter_tree() -> void:
 	_set_neovim_active(true)
@@ -28,3 +33,31 @@ func _set_neovim_active(active: bool) -> void:
 	for node in nodes:
 		if node.has_method(&"set_plugin_active"):
 			node.set_plugin_active(active)
+			if active:
+				_setup_input_handler(node)
+			else:
+				_cleanup_input_handler()
+
+
+func _setup_input_handler(plugin_node: Node) -> void:
+	_input_handler = GodotNeovimInput.new()
+	_input_handler.setup(plugin_node)
+	plugin_node.set_input_handler(Callable(_input_handler, &"_on_dispatch"))
+	print("[godot-neovim] GDScript input handler registered")
+
+	# Add keymap editor as dockable panel (right side, like Inspector)
+	_keymap_editor = GodotNeovimKeymapEditor.new()
+	_keymap_editor.name = &"Neovim Keymaps"
+	_keymap_editor.setup(plugin_node, _input_handler)
+	add_control_to_dock(DOCK_SLOT_RIGHT_BL, _keymap_editor)
+	print("[godot-neovim] Keymap editor dock added")
+
+
+func _cleanup_input_handler() -> void:
+	if _keymap_editor:
+		remove_control_from_docks(_keymap_editor)
+		_keymap_editor.queue_free()
+		_keymap_editor = null
+	if _input_handler:
+		_input_handler.disconnect_handler()
+		_input_handler = null

--- a/src/neovim/client/execution.rs
+++ b/src/neovim/client/execution.rs
@@ -40,6 +40,28 @@ impl NeovimClient {
         })
     }
 
+    /// Execute Lua code with arguments and return the result
+    pub fn execute_lua_with_args(
+        &self,
+        lua_code: &str,
+        args: Vec<rmpv::Value>,
+    ) -> Result<rmpv::Value, String> {
+        let neovim_arc = self.neovim.clone();
+        let lua_code = lua_code.to_string();
+
+        self.runtime.block_on(async {
+            let nvim_lock = neovim_arc.lock().await;
+            if let Some(neovim) = nvim_lock.as_ref() {
+                neovim
+                    .exec_lua(&lua_code, args)
+                    .await
+                    .map_err(|e| format!("Failed to execute Lua: {}", e))
+            } else {
+                Err("Neovim not connected".to_string())
+            }
+        })
+    }
+
     /// Debug: Get current indent settings from Neovim
     #[allow(dead_code)]
     pub fn debug_get_indent_settings(&self) -> Result<String, String> {

--- a/src/plugin/input/dispatch.rs
+++ b/src/plugin/input/dispatch.rs
@@ -1,0 +1,949 @@
+//! GDScript dispatch: process_key_event implementation
+//!
+//! Translates the normal.rs state machine into a dispatch-friendly form.
+//! Instead of directly calling action_*_impl(), returns a VarDictionary
+//! telling GDScript what key was resolved and whether to dispatch it.
+
+use super::super::GodotNeovimPlugin;
+use godot::classes::Input;
+use godot::global::Key;
+use godot::prelude::*;
+
+/// Result keys for the Dictionary returned by process_key_event
+const KEY_NEEDS_DISPATCH: &str = "needs_dispatch";
+const KEY_MODE: &str = "mode";
+const KEY_RESOLVED_KEY: &str = "resolved_key";
+const KEY_PASS_THROUGH: &str = "pass_through";
+
+impl GodotNeovimPlugin {
+    /// Mark the current input event as handled (prevent Godot's default handling)
+    fn mark_input_handled(&self) {
+        if let Some(mut viewport) = self.base().get_viewport() {
+            viewport.set_input_as_handled();
+        }
+    }
+
+    /// Create a result dict indicating the key was handled internally (no GDScript dispatch needed)
+    fn dispatch_handled(&self) -> VarDictionary {
+        self.mark_input_handled();
+        let mut dict = VarDictionary::new();
+        dict.set(KEY_NEEDS_DISPATCH, false);
+        dict
+    }
+
+    /// Create a result dict indicating the key should be dispatched to GDScript keymap
+    fn dispatch_key(&self, resolved_key: &str) -> VarDictionary {
+        self.mark_input_handled();
+        let mut dict = VarDictionary::new();
+        dict.set(KEY_NEEDS_DISPATCH, true);
+        dict.set(KEY_MODE, GString::from(&self.current_mode));
+        dict.set(KEY_RESOLVED_KEY, GString::from(resolved_key));
+        dict
+    }
+
+    /// Create a result dict indicating the key should pass through to Godot
+    fn dispatch_pass_through(&self) -> VarDictionary {
+        // Do NOT mark as handled - let Godot process it
+        let mut dict = VarDictionary::new();
+        dict.set(KEY_NEEDS_DISPATCH, false);
+        dict.set(KEY_PASS_THROUGH, true);
+        dict
+    }
+
+    /// Main process_key_event implementation.
+    /// Called by GDScript input handler to resolve a key event.
+    /// Process a key event for normal/visual mode and return dispatch info.
+    /// Called from input() after mode routing (command/search/insert/replace/pending ops)
+    /// has already been handled. Only processes normal/visual mode keys.
+    pub(in crate::plugin) fn process_key_event_impl(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> VarDictionary {
+        // =====================================================================
+        // Normal/Visual mode key processing
+        // (Mode routing is done by input() before calling this)
+        // =====================================================================
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // ----- Ctrl+/ (toggle comment) → pass through to Godot -----
+        if key_event.is_command_or_control_pressed() && keycode == Key::SLASH {
+            self.action_toggle_comment_impl();
+            return self.dispatch_pass_through();
+        }
+
+        // ----- Ctrl+key combinations → dispatch to GDScript keymap -----
+        if key_event.is_ctrl_pressed() {
+            if let Some(resolved) = self.resolve_ctrl_key(key_event) {
+                return self.dispatch_key(&resolved);
+            }
+        }
+
+        // ----- 'o' in visual mode: toggle selection direction (internal) -----
+        if Self::is_visual_mode(&self.current_mode)
+            && keycode == Key::O
+            && !key_event.is_ctrl_pressed()
+            && !key_event.is_shift_pressed()
+        {
+            self.send_keys("o");
+            if self.current_mode == "v" {
+                self.update_visual_selection();
+            } else if self.current_mode == "V" {
+                self.update_visual_line_selection();
+            }
+            crate::verbose_print!("[godot-neovim] o: Toggle visual selection direction");
+            return self.dispatch_handled();
+        }
+
+        // ----- Pending prefix resolution -----
+        // Must check before single-key handling to resolve g+key, [+key, etc.
+        if let Some(result) = self.resolve_pending_prefix(key_event) {
+            return result;
+        }
+
+        // ----- Register-aware operations -----
+        if let Some(result) = self.handle_register_operations(key_event) {
+            return result;
+        }
+
+        // ----- Count prefix (digits) -----
+        if let Some(c) = unicode_char {
+            if c.is_ascii_digit() && (c != '0' || !self.count_buffer.is_empty()) {
+                self.count_buffer.push(c);
+                self.send_keys(&c.to_string());
+                self.last_key_time = Some(std::time::Instant::now());
+                return self.dispatch_handled();
+            }
+        }
+
+        // ----- Side-effect keys (handled internally) -----
+        if let Some(result) = self.handle_side_effect_keys(key_event) {
+            return result;
+        }
+
+        // ----- Pending state setup keys -----
+        if let Some(result) = self.handle_pending_state_setup(key_event) {
+            return result;
+        }
+
+        // ----- Operator keys (>>, <<, > motion, < motion) -----
+        if let Some(result) = self.handle_operator_keys(key_event) {
+            return result;
+        }
+
+        // ----- Prefix key accumulation (g, [, ], Z) -----
+        if let Some(result) = self.handle_prefix_key_accumulation(key_event) {
+            return result;
+        }
+
+        // ----- Visual mode type tracking -----
+        if keycode == Key::V && !key_event.is_ctrl_pressed() {
+            if key_event.is_shift_pressed() {
+                self.visual_mode_type = 'V';
+            } else {
+                self.visual_mode_type = 'v';
+            }
+        }
+
+        // =====================================================================
+        // Phase 3: Default - convert to Neovim notation and dispatch
+        // =====================================================================
+        if let Some(keys) = self.key_event_to_nvim_string(key_event) {
+            // Record key for macro if recording
+            if self.recording_macro.is_some() && !self.playing_macro {
+                self.macro_buffer.push(keys.clone());
+            }
+
+            // Handle scroll commands (zz, zt, zb) after sending key
+            let completed = self.send_keys(&keys);
+            let scroll_handled = if completed {
+                self.handle_scroll_command(&keys)
+            } else {
+                false
+            };
+
+            // Track last key for sequence detection
+            if !scroll_handled && !self.is_insert_mode() && !self.is_replace_mode() {
+                if self.is_in_visual_mode() {
+                    if keys == "i" || keys == "a" {
+                        self.set_last_key(keys);
+                    }
+                } else {
+                    self.set_last_key(keys);
+                }
+            }
+
+            return self.dispatch_handled();
+        }
+
+        // Key couldn't be converted - ignore
+        self.dispatch_handled()
+    }
+
+    // =====================================================================
+    // Helper: Resolve Ctrl+key to Neovim notation for GDScript dispatch
+    // =====================================================================
+    fn resolve_ctrl_key(&self, key_event: &Gd<godot::classes::InputEventKey>) -> Option<String> {
+        let keycode = key_event.get_keycode();
+        match keycode {
+            Key::B
+            | Key::F
+            | Key::D
+            | Key::U
+            | Key::Y
+            | Key::E
+            | Key::A
+            | Key::X
+            | Key::O
+            | Key::I
+            | Key::G
+            | Key::R => {
+                let ch = match keycode {
+                    Key::B => 'b',
+                    Key::F => 'f',
+                    Key::D => 'd',
+                    Key::U => 'u',
+                    Key::Y => 'y',
+                    Key::E => 'e',
+                    Key::A => 'a',
+                    Key::X => 'x',
+                    Key::O => 'o',
+                    Key::I => 'i',
+                    Key::G => 'g',
+                    Key::R => 'r',
+                    _ => unreachable!(),
+                };
+                Some(format!("<C-{}>", ch))
+            }
+            _ => None,
+        }
+    }
+
+    // =====================================================================
+    // Helper: Resolve pending prefix keys (g, [, ], Z, >, <)
+    // =====================================================================
+    fn resolve_pending_prefix(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // --- g-prefix resolution ---
+        if self.last_key == "g" {
+            if let Some(keys) = self.key_event_to_nvim_string(key_event) {
+                let resolved = format!("g{}", keys);
+                self.clear_last_key();
+                return Some(self.dispatch_key(&resolved));
+            }
+            // Modifier-only key - don't clear prefix
+            return Some(self.dispatch_handled());
+        }
+
+        // --- [-prefix resolution ---
+        if self.last_key == "[" {
+            // [[ - use keycode for keyboard layout independence
+            if keycode == Key::BRACKETLEFT
+                && !key_event.is_shift_pressed()
+                && !key_event.is_ctrl_pressed()
+            {
+                self.clear_last_key();
+                self.send_keys("[[");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("[[".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            // [] - use keycode
+            if keycode == Key::BRACKETRIGHT
+                && !key_event.is_shift_pressed()
+                && !key_event.is_ctrl_pressed()
+            {
+                self.clear_last_key();
+                self.send_keys("[]");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("[]".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            // [p
+            if keycode == Key::P && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+                self.clear_last_key();
+                self.send_keys("[p");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("[p".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            match unicode_char {
+                Some('{') | Some('(') | Some('m') => {
+                    let ch = unicode_char.unwrap();
+                    let cmd = format!("[{}", ch);
+                    self.clear_last_key();
+                    self.send_keys(&cmd);
+                    if self.recording_macro.is_some() && !self.playing_macro {
+                        self.macro_buffer.push(cmd);
+                    }
+                    return Some(self.dispatch_handled());
+                }
+                Some('\0') | None => {
+                    // Modifier-only key - don't clear prefix
+                    return Some(self.dispatch_handled());
+                }
+                _ => {
+                    self.clear_last_key();
+                    // Not a recognized [ command, fall through
+                }
+            }
+        }
+
+        // --- ]-prefix resolution ---
+        if self.last_key == "]" {
+            // ]] - use keycode
+            if keycode == Key::BRACKETRIGHT
+                && !key_event.is_shift_pressed()
+                && !key_event.is_ctrl_pressed()
+            {
+                self.clear_last_key();
+                self.send_keys("]]");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("]]".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            // ][ - use keycode
+            if keycode == Key::BRACKETLEFT
+                && !key_event.is_shift_pressed()
+                && !key_event.is_ctrl_pressed()
+            {
+                self.clear_last_key();
+                self.send_keys("][");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("][".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            // ]p
+            if keycode == Key::P && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+                self.clear_last_key();
+                self.send_keys("]p");
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("]p".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            match unicode_char {
+                Some('}') | Some(')') | Some('m') => {
+                    let ch = unicode_char.unwrap();
+                    let cmd = format!("]{}", ch);
+                    self.clear_last_key();
+                    self.send_keys(&cmd);
+                    if self.recording_macro.is_some() && !self.playing_macro {
+                        self.macro_buffer.push(cmd);
+                    }
+                    return Some(self.dispatch_handled());
+                }
+                Some('\0') | None => {
+                    return Some(self.dispatch_handled());
+                }
+                _ => {
+                    self.clear_last_key();
+                }
+            }
+        }
+
+        // --- Z-prefix resolution ---
+        if self.last_key == "Z" {
+            if keycode == Key::Z && key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+                self.clear_last_key();
+                return Some(self.dispatch_key("ZZ"));
+            }
+            if keycode == Key::Q && key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+                self.clear_last_key();
+                return Some(self.dispatch_key("ZQ"));
+            }
+            // Clear Z prefix if another key
+            self.clear_last_key();
+        }
+
+        // --- >-prefix resolution ---
+        if self.last_key == ">" {
+            if let Some(ch) = unicode_char {
+                if ch == '>' {
+                    // >> indent
+                    self.send_keys(">>");
+                    self.clear_last_key();
+                    if self.recording_macro.is_some() && !self.playing_macro {
+                        self.macro_buffer.push(">>".to_string());
+                    }
+                    return Some(self.dispatch_handled());
+                } else {
+                    // > + motion
+                    self.send_keys(&format!(">{}", ch));
+                    self.clear_last_key();
+                    return Some(self.dispatch_handled());
+                }
+            }
+        }
+
+        // --- <-prefix resolution ---
+        if self.last_key == "<" {
+            if let Some(ch) = unicode_char {
+                if ch == '<' {
+                    // << unindent
+                    self.send_keys("<LT><LT>");
+                    self.clear_last_key();
+                    if self.recording_macro.is_some() && !self.playing_macro {
+                        self.macro_buffer.push("<<".to_string());
+                    }
+                    return Some(self.dispatch_handled());
+                } else {
+                    // < + motion
+                    self.send_keys(&format!("<LT>{}", ch));
+                    self.clear_last_key();
+                    return Some(self.dispatch_handled());
+                }
+            }
+        }
+
+        // --- gq-prefix resolution ---
+        if self.last_key == "gq" {
+            if keycode == Key::Q && !key_event.is_shift_pressed() {
+                self.send_keys("gqq");
+                self.clear_last_key();
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("gqq".to_string());
+                }
+                return Some(self.dispatch_handled());
+            }
+            // Other key after gq: gq + motion
+            if let Some(keys) = self.key_event_to_nvim_string(key_event) {
+                self.send_keys(&format!("gq{}", keys));
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Helper: Handle register-aware operations ("ayy, "ap, etc.)
+    // =====================================================================
+    fn handle_register_operations(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let reg = self.selected_register?;
+        if reg == '\0' {
+            return None; // Waiting for register char - handled by mode_handler
+        }
+
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // Count prefix within register context
+        if let Some(c) = unicode_char {
+            if c.is_ascii_digit() && (c != '0' || !self.count_buffer.is_empty()) {
+                self.count_buffer.push(c);
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        // yy - yank line to register
+        if keycode == Key::Y && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            if self.last_key == "y" {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}yy", reg, count_str));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            } else {
+                self.set_last_key("y");
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        // p - paste from register
+        if keycode == Key::P && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            self.send_keys(&format!("\"{}p", reg));
+            self.selected_register = None;
+            self.count_buffer.clear();
+            return Some(self.dispatch_handled());
+        }
+
+        // P - paste before from register
+        if keycode == Key::P && key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            self.send_keys(&format!("\"{}P", reg));
+            self.selected_register = None;
+            self.count_buffer.clear();
+            return Some(self.dispatch_handled());
+        }
+
+        // dd - delete line to register
+        if keycode == Key::D && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            if self.last_key == "d" {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}dd", reg, count_str));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            } else {
+                self.set_last_key("d");
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        // cc - change line to register
+        if keycode == Key::C && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            if self.last_key == "c" {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}cc", reg, count_str));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            } else {
+                self.set_last_key("c");
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        // Operator + motion with register (y/d/c + motion)
+        if let Some(keys) = self.key_event_to_nvim_string(key_event) {
+            if self.last_key == "y" && keycode != Key::Y {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}y{}", reg, count_str, keys));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            }
+            if self.last_key == "d" && keycode != Key::D {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}d{}", reg, count_str, keys));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            }
+            if self.last_key == "c" && keycode != Key::C {
+                let count = self.get_and_clear_count();
+                let count_str = if count > 1 {
+                    count.to_string()
+                } else {
+                    String::new()
+                };
+                self.send_keys(&format!("\"{}{}c{}", reg, count_str, keys));
+                self.selected_register = None;
+                self.clear_last_key();
+                return Some(self.dispatch_handled());
+            }
+        }
+
+        // Other keys cancel register selection
+        if keycode != Key::Y && keycode != Key::D && keycode != Key::C {
+            self.selected_register = None;
+            self.count_buffer.clear();
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Helper: Handle keys with Godot side effects (internal handling)
+    // =====================================================================
+    fn handle_side_effect_keys(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // ';' - repeat find char same direction
+        if keycode == Key::SEMICOLON && !key_event.is_shift_pressed() {
+            self.repeat_find_char(true);
+            self.send_keys(";");
+            if self.recording_macro.is_some() && !self.playing_macro {
+                self.macro_buffer.push(";".to_string());
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        // ',' - repeat find char opposite direction
+        if keycode == Key::COMMA && !key_event.is_shift_pressed() {
+            self.repeat_find_char(false);
+            self.send_keys(",");
+            if self.recording_macro.is_some() && !self.playing_macro {
+                self.macro_buffer.push(",".to_string());
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        // '%' - matching bracket
+        if unicode_char == Some('%') {
+            self.jump_to_matching_bracket();
+            self.send_keys("%");
+            if self.recording_macro.is_some() && !self.playing_macro {
+                self.macro_buffer.push("%".to_string());
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        // '0' - go to start of line (only when not part of a count, not after g)
+        if unicode_char == Some('0') && !key_event.is_ctrl_pressed() && self.last_key != "g" {
+            self.move_to_line_start();
+            self.send_keys("0");
+            return Some(self.dispatch_handled());
+        }
+
+        // '^' - go to first non-blank (not after g)
+        if unicode_char == Some('^') && self.last_key != "g" {
+            self.move_to_first_non_blank();
+            self.send_keys("^");
+            return Some(self.dispatch_handled());
+        }
+
+        // '$' - go to end of line (not after g)
+        if unicode_char == Some('$') && self.last_key != "g" {
+            self.move_to_line_end();
+            self.send_keys("$");
+            return Some(self.dispatch_handled());
+        }
+
+        // 'J' - join lines (not after g - that's gJ)
+        if keycode == Key::J
+            && key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "g"
+        {
+            self.send_keys("J");
+            return Some(self.dispatch_handled());
+        }
+
+        // H/M/L - viewport-relative movement
+        if !key_event.is_ctrl_pressed()
+            && !key_event.is_alt_pressed()
+            && (keycode == Key::H || keycode == Key::M || keycode == Key::L)
+            && key_event.is_shift_pressed()
+        {
+            let key_str = match keycode {
+                Key::H => "H",
+                Key::M => "M",
+                Key::L => "L",
+                _ => unreachable!(),
+            };
+            self.send_keys(key_str);
+            return Some(self.dispatch_handled());
+        }
+
+        // 'R' - enter replace mode
+        if keycode == Key::R && key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            if self.recording_macro.is_some() && !self.playing_macro {
+                self.macro_buffer.push("R".to_string());
+            }
+            self.enter_replace_mode();
+            return Some(self.dispatch_handled());
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Helper: Handle keys that set up pending states
+    // =====================================================================
+    fn handle_pending_state_setup(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // 'f' - find char forward (not after g/i/a prefix)
+        if keycode == Key::F
+            && !key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "g"
+            && self.last_key != "i"
+            && self.last_key != "a"
+        {
+            self.clear_pending_input_states();
+            self.pending_char_op = Some('f');
+            return Some(self.dispatch_handled());
+        }
+
+        // 'F' - find char backward (not after i/a prefix)
+        if keycode == Key::F
+            && key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "i"
+            && self.last_key != "a"
+        {
+            self.clear_pending_input_states();
+            self.pending_char_op = Some('F');
+            return Some(self.dispatch_handled());
+        }
+
+        // 't' - till char forward (not after g/z/i/a prefix)
+        if keycode == Key::T
+            && !key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "g"
+            && self.last_key != "z"
+            && self.last_key != "i"
+            && self.last_key != "a"
+        {
+            self.clear_pending_input_states();
+            self.pending_char_op = Some('t');
+            return Some(self.dispatch_handled());
+        }
+
+        // 'T' - till char backward (not after g/i/a prefix)
+        if keycode == Key::T
+            && key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "g"
+            && self.last_key != "i"
+            && self.last_key != "a"
+        {
+            self.clear_pending_input_states();
+            self.pending_char_op = Some('T');
+            return Some(self.dispatch_handled());
+        }
+
+        // 'r' - replace char
+        if keycode == Key::R && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            self.clear_pending_input_states();
+            self.pending_char_op = Some('r');
+            return Some(self.dispatch_handled());
+        }
+
+        // 'm' - set mark
+        if keycode == Key::M && !key_event.is_shift_pressed() && !key_event.is_ctrl_pressed() {
+            self.clear_pending_input_states();
+            self.pending_mark_op = Some('m');
+            return Some(self.dispatch_handled());
+        }
+
+        // '\'' - jump to mark line (not in operator-pending or visual mode)
+        if unicode_char == Some('\'')
+            && !key_event.is_ctrl_pressed()
+            && self.current_mode != "operator"
+            && !Self::is_visual_mode(&self.current_mode)
+        {
+            self.clear_pending_input_states();
+            self.pending_mark_op = Some('\'');
+            return Some(self.dispatch_handled());
+        }
+
+        // '`' - jump to mark position (not in operator-pending or visual mode)
+        if unicode_char == Some('`')
+            && !key_event.is_ctrl_pressed()
+            && self.current_mode != "operator"
+            && !Self::is_visual_mode(&self.current_mode)
+        {
+            self.clear_pending_input_states();
+            self.pending_mark_op = Some('`');
+            return Some(self.dispatch_handled());
+        }
+
+        // 'q' - macro recording start/stop (not after g, not with AltGr)
+        let input = Input::singleton();
+        let is_altgr_held = input.is_key_pressed(Key::CTRL) && input.is_key_pressed(Key::ALT);
+        if keycode == Key::Q
+            && !key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && !is_altgr_held
+            && self.last_key != "g"
+        {
+            if self.recording_macro.is_some() {
+                self.stop_macro_recording();
+            } else {
+                self.clear_pending_input_states();
+                self.pending_macro_op = Some('q');
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        // '@' - macro playback
+        if unicode_char == Some('@') && !key_event.is_ctrl_pressed() {
+            self.clear_pending_input_states();
+            self.pending_macro_op = Some('@');
+            return Some(self.dispatch_handled());
+        }
+
+        // '"' - register selection (not in operator-pending or visual mode)
+        if unicode_char == Some('"')
+            && !key_event.is_ctrl_pressed()
+            && self.current_mode != "operator"
+            && !Self::is_visual_mode(&self.current_mode)
+        {
+            self.clear_pending_input_states();
+            self.clear_last_key();
+            self.selected_register = Some('\0');
+            return Some(self.dispatch_handled());
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Helper: Handle operator keys (>, <)
+    // =====================================================================
+    fn handle_operator_keys(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // '>' - indent operator
+        if unicode_char == Some('>') {
+            if self.last_key == ">" {
+                self.send_keys(">>");
+                self.clear_last_key();
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push(">>".to_string());
+                }
+            } else {
+                self.set_last_key(">");
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        // '<' - unindent operator
+        if unicode_char == Some('<') {
+            if self.last_key == "<" {
+                self.send_keys("<LT><LT>");
+                self.clear_last_key();
+                if self.recording_macro.is_some() && !self.playing_macro {
+                    self.macro_buffer.push("<<".to_string());
+                }
+            } else {
+                self.set_last_key("<");
+            }
+            return Some(self.dispatch_handled());
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Helper: Prefix key accumulation (g, [, ], Z)
+    // =====================================================================
+    fn handle_prefix_key_accumulation(
+        &mut self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<VarDictionary> {
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+
+        // 'g' prefix (not after another g - allow gg)
+        if unicode_char == Some('g')
+            && !key_event.is_ctrl_pressed()
+            && !key_event.is_shift_pressed()
+            && self.last_key != "g"
+        {
+            self.set_last_key("g");
+            return Some(self.dispatch_handled());
+        }
+
+        // '[' prefix (not after [ or ])
+        if keycode == Key::BRACKETLEFT
+            && !key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "["
+            && self.last_key != "]"
+        {
+            self.set_last_key("[");
+            return Some(self.dispatch_handled());
+        }
+
+        // ']' prefix (not after [ or ])
+        if keycode == Key::BRACKETRIGHT
+            && !key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "["
+            && self.last_key != "]"
+        {
+            self.set_last_key("]");
+            return Some(self.dispatch_handled());
+        }
+
+        // 'Z' prefix (Shift+Z)
+        if keycode == Key::Z
+            && key_event.is_shift_pressed()
+            && !key_event.is_ctrl_pressed()
+            && self.last_key != "Z"
+        {
+            self.set_last_key("Z");
+            return Some(self.dispatch_handled());
+        }
+
+        None
+    }
+
+    // =====================================================================
+    // Get Neovim keymaps via RPC
+    // =====================================================================
+    pub(in crate::plugin) fn get_neovim_keymaps_impl(&self, mode: &str) -> VarDictionary {
+        let mut dict = VarDictionary::new();
+
+        let Some(neovim_mutex) = self.get_current_neovim() else {
+            return dict;
+        };
+
+        let Ok(neovim) = neovim_mutex.lock() else {
+            return dict;
+        };
+
+        // Use exec_lua to get keymaps and return a simplified table
+        let lua_code = r#"
+            local mode = ...
+            local maps = vim.api.nvim_get_keymap(mode)
+            local result = {}
+            for _, map in ipairs(maps) do
+                if map.lhs and map.rhs then
+                    result[map.lhs] = map.rhs
+                end
+            end
+            return result
+        "#;
+
+        let result = neovim.execute_lua_with_args(lua_code, vec![rmpv::Value::from(mode)]);
+
+        if let Ok(rmpv::Value::Map(entries)) = result {
+            // Convert rmpv::Value (Map) to VarDictionary
+            for (k, v) in entries {
+                if let (rmpv::Value::String(lhs), rmpv::Value::String(rhs)) = (k, v) {
+                    if let (Some(lhs_str), Some(rhs_str)) = (lhs.as_str(), rhs.as_str()) {
+                        dict.set(GString::from(lhs_str), GString::from(rhs_str));
+                    }
+                }
+            }
+        }
+
+        dict
+    }
+}

--- a/src/plugin/input/mod.rs
+++ b/src/plugin/input/mod.rs
@@ -9,6 +9,7 @@
 //! - normal: Normal mode (largest, may be further split)
 
 mod command;
+mod dispatch;
 mod insert;
 mod normal;
 mod pending;

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -367,6 +367,10 @@ pub struct GodotNeovimPlugin {
     /// so we use this flag to defer initialization until plugin.gd calls set_plugin_active.
     #[init(val = false)]
     plugin_active: bool,
+    /// GDScript input handler Callable (when set, delegates input dispatch to GDScript)
+    /// This enables GDScript-based keybinding customization without recompiling the GDExtension.
+    #[init(val = None)]
+    input_handler: Option<Callable>,
 }
 
 #[godot_api]
@@ -670,7 +674,20 @@ impl IEditorPlugin for GodotNeovimPlugin {
         }
 
         // Handle normal/visual mode input
-        self.handle_normal_mode_input(&key_event);
+        if self.input_handler.is_some() {
+            // GDScript dispatch path: process key in Rust, defer keymap lookup to GDScript.
+            // Cannot call GDScript Callable directly here (re-entrant &mut self borrow).
+            let result = self.process_key_event_impl(&key_event);
+            if result.get_or_nil("needs_dispatch").to::<bool>() {
+                let resolved_key = result.get_or_nil("resolved_key");
+                let mode = result.get_or_nil("mode");
+                self.base_mut()
+                    .call_deferred("_dispatch_key_to_gdscript", &[resolved_key, mode]);
+            }
+        } else {
+            // Fallback: built-in Rust handling
+            self.handle_normal_mode_input(&key_event);
+        }
     }
 }
 
@@ -1492,6 +1509,124 @@ impl GodotNeovimPlugin {
             self.restart_neovim();
         }
         self.cleanup_recovery_dialog();
+    }
+
+    // =========================================================================
+    // Input handler API: GDScript-based keybinding dispatch
+    // =========================================================================
+
+    /// Register a GDScript Callable as the keymap dispatch handler.
+    /// When set, input() uses process_key_event for normal/visual mode,
+    /// then defers keymap lookup to this Callable via call_deferred.
+    /// The Callable signature should be: func(resolved_key: String, mode: String) -> void
+    #[func]
+    fn set_input_handler(&mut self, handler: Callable) {
+        crate::verbose_print!("[godot-neovim] GDScript input handler registered");
+        self.input_handler = Some(handler);
+    }
+
+    /// Deferred dispatch: called via call_deferred from input() to avoid re-entrant borrow.
+    /// Invokes the GDScript dispatch handler with the resolved key and mode.
+    #[func]
+    fn _dispatch_key_to_gdscript(&mut self, resolved_key: GString, mode: GString) {
+        if let Some(handler) = self.input_handler.clone() {
+            handler.call(&[resolved_key.to_variant(), mode.to_variant()]);
+        }
+    }
+
+    /// Clear the GDScript input handler, reverting to built-in Rust handling.
+    #[func]
+    fn clear_input_handler(&mut self) {
+        crate::verbose_print!("[godot-neovim] GDScript input handler cleared");
+        self.input_handler = None;
+    }
+
+    /// Handle mouse events (called by GDScript input handler).
+    /// Extracts mouse handling logic from input() for GDScript delegation.
+    #[func]
+    fn handle_mouse_event(&mut self, event: Gd<godot::classes::InputEvent>) {
+        let Ok(mouse_event) = event.try_cast::<godot::classes::InputEventMouseButton>() else {
+            return;
+        };
+
+        if mouse_event.get_button_index() == godot::global::MouseButton::LEFT
+            && self.editor_has_focus()
+        {
+            if mouse_event.is_pressed() {
+                self.mouse_dragging = true;
+                self.mouse_selection_syncing = false;
+                if let Some(ref mut editor) = self.current_editor {
+                    editor.set_selecting_enabled(true);
+                }
+            } else if self.mouse_dragging {
+                self.mouse_dragging = false;
+                self.base_mut()
+                    .call_deferred("sync_mouse_selection_to_neovim", &[]);
+            }
+        }
+    }
+
+    /// Handle mode-specific input (insert/replace/command/search and pending ops).
+    /// Called by GDScript when process_key_event returns mode_handler=true.
+    #[func]
+    fn handle_mode_input(&mut self, event: Gd<godot::classes::InputEventKey>) {
+        // Command-line mode
+        if self.command_mode {
+            self.handle_command_mode_input(&event);
+            return;
+        }
+
+        // Search mode
+        if self.search_mode {
+            self.handle_search_mode_input(&event);
+            return;
+        }
+
+        // Pending operations
+        if self.handle_pending_char_op(&event) {
+            return;
+        }
+        if self.handle_pending_mark_op(&event) {
+            return;
+        }
+        if self.handle_pending_macro_op(&event) {
+            return;
+        }
+        if self.handle_pending_register(&event) {
+            return;
+        }
+
+        // Insert mode
+        if self.is_insert_mode() {
+            self.handle_insert_mode_input(&event);
+            return;
+        }
+
+        // Replace mode
+        if self.is_replace_mode() {
+            self.handle_replace_mode_input(&event);
+        }
+    }
+
+    /// Process a key event and return dispatch information for GDScript.
+    /// Returns a Dictionary with:
+    /// - "needs_dispatch": bool - whether GDScript should look up the keymap
+    /// - "mode": String - current vim mode ("n", "v", "V", etc.)
+    /// - "resolved_key": String - resolved key in Neovim notation ("gd", "<C-f>", etc.)
+    /// - "mode_handler": bool - whether to call handle_mode_input() instead
+    /// - "pass_through": bool - whether to let Godot handle the key (e.g., Ctrl+/)
+    #[func]
+    fn process_key_event(&mut self, event: Gd<godot::classes::InputEventKey>) -> VarDictionary {
+        self.process_key_event_impl(&event)
+    }
+
+    /// Get Neovim's current keymaps for a mode via RPC.
+    /// Returns a Dictionary of { lhs: rhs } mappings.
+    /// Only contains user-defined mappings (not built-in Neovim defaults).
+    /// Requires Neovim to be connected; returns empty dict otherwise.
+    #[func]
+    fn get_neovim_keymaps(&self, mode: GString) -> VarDictionary {
+        self.get_neovim_keymaps_impl(&mode.to_string())
     }
 
     // =========================================================================


### PR DESCRIPTION
Enable keybinding customization without recompiling the GDExtension. Keybindings are managed through a dockable "Neovim Keymaps" settings panel and persisted in EditorSettings (godot_neovim/custom_keymaps).

Rust side:
- Add process_key_event_impl() in dispatch.rs to resolve key sequences (prefix keys, count, register ops) and return resolved key strings
- Add set_input_handler/clear_input_handler for GDScript dispatch
- Use call_deferred dispatch to avoid re-entrant borrow panics
- Add get_neovim_keymaps() for importing Neovim keymaps via RPC
- Modify input() to use process_key_event + deferred GDScript dispatch when input_handler is registered, with fallback to built-in normal.rs

GDScript side:
- Add godot_neovim_input.gd: dispatch handler with keymap lookup and EditorSettings integration
- Add keymap_editor.gd: dockable GUI panel for viewing/editing keymaps with key validation, duplicate detection, and Import from Neovim
- Add default_keymaps.gd: default key-to-action mappings (already existed)
- Update plugin.gd: setup input handler and keymap editor dock
- Update README.md: document custom key mappings, update comparison table