### PR TITLE
fix: dispatch single-key actions via GDScript keymap

### DIFF
--- a/src/plugin/input/dispatch.rs
+++ b/src/plugin/input/dispatch.rs
@@ -136,6 +136,13 @@ impl GodotNeovimPlugin {
             return result;
         }
 
+        // ----- Dispatchable single keys (mapped to GDScript actions) -----
+        // Keys like /, ?, :, n, N, *, #, u, K open Godot-side UI or call LSP,
+        // and must go through the keymap dispatch (not sent directly to Neovim).
+        if let Some(resolved) = self.resolve_dispatchable_single_key(key_event) {
+            return self.dispatch_key(&resolved);
+        }
+
         // ----- Visual mode type tracking -----
         if keycode == Key::V && !key_event.is_ctrl_pressed() {
             if key_event.is_shift_pressed() {
@@ -217,6 +224,65 @@ impl GodotNeovimPlugin {
             }
             _ => None,
         }
+    }
+
+    // =====================================================================
+    // Helper: Resolve dispatchable single keys (/, ?, :, n, N, *, #, u, K)
+    // These open Godot-side UI (search, command line) or call LSP (goto def,
+    // documentation), so they must go through GDScript keymap dispatch rather
+    // than being sent directly to Neovim.
+    // =====================================================================
+    fn resolve_dispatchable_single_key(
+        &self,
+        key_event: &Gd<godot::classes::InputEventKey>,
+    ) -> Option<String> {
+        let keycode = key_event.get_keycode();
+        let unicode_char = char::from_u32(key_event.get_unicode());
+        let ctrl = key_event.is_ctrl_pressed();
+        let shift = key_event.is_shift_pressed();
+
+        if ctrl {
+            return None;
+        }
+
+        // '/' - forward search
+        if unicode_char == Some('/') {
+            return Some("/".to_string());
+        }
+        // '?' - backward search
+        if unicode_char == Some('?') {
+            return Some("?".to_string());
+        }
+        // ':' - command line
+        if unicode_char == Some(':') {
+            return Some(":".to_string());
+        }
+        // '*' - search word forward
+        if unicode_char == Some('*') {
+            return Some("*".to_string());
+        }
+        // '#' - search word backward
+        if unicode_char == Some('#') {
+            return Some("#".to_string());
+        }
+        // 'n' - search next (not Shift)
+        if keycode == Key::N && !shift {
+            return Some("n".to_string());
+        }
+        // 'N' - search previous (Shift+N)
+        if keycode == Key::N && shift {
+            return Some("N".to_string());
+        }
+        // 'u' - undo (not Shift, not after 'g' prefix which is gu = lowercase operator)
+        if keycode == Key::U && !shift && self.last_key != "g" {
+            return Some("u".to_string());
+        }
+        // 'K' - documentation (Shift+K, not after 'g' prefix which is gK)
+        if keycode == Key::K && shift && self.last_key != "g" {
+            return Some("K".to_string());
+        }
+
+        None
     }
 
     // =====================================================================


### PR DESCRIPTION
## Summary
- Fix `/`, `?`, `:` and other single-key actions being sent directly to Neovim instead of triggering Godot-side UI
- Add `resolve_dispatchable_single_key()` helper to route these keys through the GDScript keymap dispatch path
- Covers: `/`, `?`, `:`, `*`, `#`, `n`, `N`, `u`, `K` (with proper `g`-prefix guards for `u`/`K`)

## Root cause
After moving keybindings to GDScript (#64), `dispatch.rs` Phase 3 (default path) called `send_keys()` directly instead of dispatching to GDScript. Keys that should open Godot-side UI (search dialog, command line, LSP goto) were sent to Neovim, which briefly entered `cmdline_normal` mode before timing out.

Fixes #65

## Test plan
- [ ] Press `/` in normal mode: Godot search prompt opens (not Neovim cmdline_normal)
- [ ] Press `:` in normal mode: Godot command line opens
- [ ] Press `*` / `#`: search for word under cursor
- [ ] Press `n` / `N`: repeat search in forward/backward direction
- [ ] Press `u`: undo works (not after `g` to preserve `gu` operator)
- [ ] Press `Shift+K`: documentation opens (not after `g` to preserve `gK`)
- [ ] Verify `gu{motion}` still works as lowercase operator
- [ ] Verify fast typing (`hjkl`, `w`, `b`, etc.) is not affected by added dispatch logic