### PR TITLE
chore: upgrade godot-rs to 0.5 with api-4-4 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ repository = "https://github.com/shiena/godot-neovim"
 crate-type = ["cdylib"]
 
 [dependencies]
-godot = "0.4.5"
+godot = { version = "0.5", features = ["api-4-4"] }
 nvim-rs = { version = "0.9", features = ["use_tokio"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1.51", features = ["full"] }
 futures = "0.3"
-rmpv = "1.0"
+rmpv = "1.3"
 async-trait = "0.1"
 lsp-types = "0.97"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/plugin/commands/buffer_nav.rs
+++ b/src/plugin/commands/buffer_nav.rs
@@ -42,7 +42,7 @@ impl GodotNeovimPlugin {
         }
 
         let mut editor = EditorInterface::singleton();
-        let Some(mut script_editor) = editor.get_script_editor() else {
+        let Some(script_editor) = editor.get_script_editor() else {
             return;
         };
 
@@ -141,11 +141,11 @@ impl GodotNeovimPlugin {
                     // Also update the ItemList selection (shader_list)
                     // ItemList is a sibling of TabContainer in HSplitContainer
                     if let Some(parent) = node.get_parent() {
-                        if parent.get_class().to_string() == "HSplitContainer" {
+                        if parent.get_class() == "HSplitContainer" {
                             let child_count = parent.get_child_count();
                             for i in 0..child_count {
                                 if let Some(mut child) = parent.get_child(i) {
-                                    if child.get_class().to_string() == "ItemList" {
+                                    if child.get_class() == "ItemList" {
                                         // Update ItemList selection to match the new tab
                                         child.call("select", &[new_idx.to_variant()]);
                                         crate::verbose_print!(
@@ -236,7 +236,7 @@ impl GodotNeovimPlugin {
     /// Called when Neovim switches buffer (e.g., via Ctrl+O/Ctrl+I jump)
     pub(crate) fn sync_godot_script_tab(&mut self, neovim_path: &str) {
         let mut editor = EditorInterface::singleton();
-        let Some(mut script_editor) = editor.get_script_editor() else {
+        let Some(script_editor) = editor.get_script_editor() else {
             return;
         };
 

--- a/src/plugin/commands/file_ops.rs
+++ b/src/plugin/commands/file_ops.rs
@@ -577,7 +577,7 @@ impl GodotNeovimPlugin {
             // Also update the Script resource to prevent Godot from
             // caching the modified content when reopening
             let editor = EditorInterface::singleton();
-            if let Some(mut script_editor) = editor.get_script_editor() {
+            if let Some(script_editor) = editor.get_script_editor() {
                 if let Some(mut current_script) = script_editor.get_current_script() {
                     current_script.set_source_code(&text);
                     crate::verbose_print!(
@@ -703,7 +703,7 @@ impl GodotNeovimPlugin {
             // Check if this is files_split (has ItemList child)
             let has_item_list = (0..node.get_child_count()).any(|i| {
                 node.get_child(i)
-                    .is_some_and(|c| c.get_class().to_string() == "ItemList")
+                    .is_some_and(|c| c.get_class() == "ItemList")
             });
 
             if has_item_list {
@@ -791,7 +791,7 @@ impl GodotNeovimPlugin {
             let child_count = node.get_child_count();
             for i in 0..child_count {
                 if let Some(child) = node.get_child(i) {
-                    if child.get_class().to_string() == "ItemList" {
+                    if child.get_class() == "ItemList" {
                         if let Ok(item_list) = child.try_cast::<ItemList>() {
                             // Collect all shader paths from ItemList tooltips
                             let item_count = item_list.get_item_count();

--- a/src/plugin/editing.rs
+++ b/src/plugin/editing.rs
@@ -222,22 +222,22 @@ impl GodotNeovimPlugin {
         };
 
         // Try to get the script path
-        let file_name =
-            if let Some(mut script_edit) = EditorInterface::singleton().get_script_editor() {
-                if let Some(current_script) = script_edit.get_current_script() {
-                    let path = current_script.get_path().to_string();
-                    if path.is_empty() {
-                        "[New File]".to_string()
-                    } else {
-                        // Extract just the filename from path
-                        path.split('/').next_back().unwrap_or(&path).to_string()
-                    }
+        let file_name = if let Some(script_edit) = EditorInterface::singleton().get_script_editor()
+        {
+            if let Some(current_script) = script_edit.get_current_script() {
+                let path = current_script.get_path().to_string();
+                if path.is_empty() {
+                    "[New File]".to_string()
                 } else {
-                    "[No Script]".to_string()
+                    // Extract just the filename from path
+                    path.split('/').next_back().unwrap_or(&path).to_string()
                 }
             } else {
-                "[Unknown]".to_string()
-            };
+                "[No Script]".to_string()
+            }
+        } else {
+            "[Unknown]".to_string()
+        };
 
         let msg = format!(
             "\"{}\" line {} of {} --{}%--",

--- a/src/plugin/editor.rs
+++ b/src/plugin/editor.rs
@@ -306,7 +306,7 @@ impl GodotNeovimPlugin {
         // This handles the case where the editor is focused but buffer wasn't synced
         // (e.g., on startup when multiple on_script_changed signals fire)
         if self.current_editor.is_some() && self.current_editor_type == EditorType::Script {
-            if let Some(mut script_editor) = editor.get_script_editor() {
+            if let Some(script_editor) = editor.get_script_editor() {
                 // Get actual current script path from ScriptEditor
                 // Also track whether it's a TextFile (get_current_script returns None)
                 let current_script = script_editor.get_current_script();
@@ -505,7 +505,7 @@ impl GodotNeovimPlugin {
     /// returning the wrong editor when multiple editors are open (issue #40)
     pub(super) fn find_visible_code_edit_safe(&self, node: Gd<Control>) -> Option<Gd<CodeEdit>> {
         let editor = EditorInterface::singleton();
-        let mut script_editor = editor.get_script_editor()?;
+        let script_editor = editor.get_script_editor()?;
         let current_script = script_editor.get_current_script()?;
         let expected_path = current_script.get_path().to_string();
 
@@ -619,7 +619,7 @@ impl GodotNeovimPlugin {
 
                         // Look for ItemList (shader_list)
                         if child_class == "ItemList" {
-                            if let Ok(mut item_list) = child.try_cast::<ItemList>() {
+                            if let Ok(item_list) = child.try_cast::<ItemList>() {
                                 // Get the selected item index
                                 let selected_items = item_list.get_selected_items();
                                 crate::verbose_print!(
@@ -942,7 +942,7 @@ impl GodotNeovimPlugin {
             None
         }
 
-        if let Some(mut item_list) = find_item_list(&node) {
+        if let Some(item_list) = find_item_list(&node) {
             // Get selected items (should be the current script/file)
             let selected = item_list.get_selected_items();
             if !selected.is_empty() {

--- a/src/plugin/input/dispatch.rs
+++ b/src/plugin/input/dispatch.rs
@@ -36,8 +36,8 @@ impl GodotNeovimPlugin {
         self.mark_input_handled();
         let mut dict = VarDictionary::new();
         dict.set(KEY_NEEDS_DISPATCH, true);
-        dict.set(KEY_MODE, GString::from(&self.current_mode));
-        dict.set(KEY_RESOLVED_KEY, GString::from(resolved_key));
+        dict.set(KEY_MODE, &GString::from(&self.current_mode));
+        dict.set(KEY_RESOLVED_KEY, &GString::from(resolved_key));
         dict
     }
 
@@ -1004,7 +1004,7 @@ impl GodotNeovimPlugin {
             for (k, v) in entries {
                 if let (rmpv::Value::String(lhs), rmpv::Value::String(rhs)) = (k, v) {
                     if let (Some(lhs_str), Some(rhs_str)) = (lhs.as_str(), rhs.as_str()) {
-                        dict.set(GString::from(lhs_str), GString::from(rhs_str));
+                        dict.set(&GString::from(lhs_str), &GString::from(rhs_str));
                     }
                 }
             }

--- a/src/plugin/mod.rs
+++ b/src/plugin/mod.rs
@@ -1163,7 +1163,7 @@ impl GodotNeovimPlugin {
         } else {
             // Verify we're on the expected script before syncing (ScriptEditor only)
             let editor = EditorInterface::singleton();
-            let Some(mut script_editor) = editor.get_script_editor() else {
+            let Some(script_editor) = editor.get_script_editor() else {
                 crate::verbose_print!("[godot-neovim] No script editor found");
                 return;
             };

--- a/src/plugin/recovery.rs
+++ b/src/plugin/recovery.rs
@@ -75,7 +75,7 @@ impl GodotNeovimPlugin {
     /// Save all open scripts via Godot's ResourceSaver
     pub(super) fn save_all_open_scripts(&mut self) {
         let editor = EditorInterface::singleton();
-        let Some(mut script_editor) = editor.get_script_editor() else {
+        let Some(script_editor) = editor.get_script_editor() else {
             crate::verbose_print!("[godot-neovim] Recovery: No script editor found");
             return;
         };

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,9 @@ const SETTING_NEOVIM_PATH: &str = "godot_neovim/neovim_executable_path";
 const SETTING_NEOVIM_CLEAN: &str = "godot_neovim/neovim_clean";
 const SETTING_TIMEOUTLEN: &str = "godot_neovim/timeoutlen";
 
+const PROPERTY_HINT_RANGE: i32 = 1;
+const PROPERTY_HINT_GLOBAL_FILE: i32 = 23;
+
 /// Default timeout for multi-key sequences (matches Neovim's default)
 pub const DEFAULT_TIMEOUTLEN_MS: i64 = 1000;
 
@@ -44,12 +47,11 @@ pub fn initialize_settings() {
     settings.set_initial_value(SETTING_NEOVIM_PATH, &Variant::from(default_path), false);
 
     // Add property info for better UI
-    #[allow(deprecated)]
-    let mut property_info = Dictionary::new();
+    let mut property_info = VarDictionary::new();
     property_info.set("name", SETTING_NEOVIM_PATH);
     property_info.set("type", VariantType::STRING.ord());
-    property_info.set("hint", godot::global::PropertyHint::GLOBAL_FILE.ord());
-    property_info.set("hint_string", get_file_filter());
+    property_info.set("hint", PROPERTY_HINT_GLOBAL_FILE);
+    property_info.set("hint_string", &get_file_filter());
 
     settings.add_property_info(&property_info);
 
@@ -63,8 +65,7 @@ pub fn initialize_settings() {
     settings.set_initial_value(SETTING_NEOVIM_CLEAN, &Variant::from(true), false);
 
     // Add property info for neovim_clean (checkbox)
-    #[allow(deprecated)]
-    let mut clean_info = Dictionary::new();
+    let mut clean_info = VarDictionary::new();
     clean_info.set("name", SETTING_NEOVIM_CLEAN);
     clean_info.set("type", VariantType::BOOL.ord());
 
@@ -83,11 +84,10 @@ pub fn initialize_settings() {
     );
 
     // Add property info for timeoutlen (integer with range)
-    #[allow(deprecated)]
-    let mut timeoutlen_info = Dictionary::new();
+    let mut timeoutlen_info = VarDictionary::new();
     timeoutlen_info.set("name", SETTING_TIMEOUTLEN);
     timeoutlen_info.set("type", VariantType::INT.ord());
-    timeoutlen_info.set("hint", godot::global::PropertyHint::RANGE.ord());
+    timeoutlen_info.set("hint", PROPERTY_HINT_RANGE);
     timeoutlen_info.set("hint_string", "0,10000,100"); // min, max, step
 
     settings.add_property_info(&timeoutlen_info);


### PR DESCRIPTION
## Summary
- Upgrade `godot` crate from 0.4 to 0.5, pinning to the `api-4-4` feature so the plugin keeps running on Godot 4.4.
- Adjust code for the 0.5 API changes: private `PropertyHint`, generic `Dictionary`, and `GString` now passed by reference.
- Clean up `mut` bindings and owned-string comparisons flagged by the new toolchain's clippy.

## Changes
- `Cargo.toml`: pin `godot = { version = "0.5", features = ["api-4-4"] }`; other deps kept at minor-version granularity.
- `src/settings.rs`: replace `godot::global::PropertyHint::*` (now `pub(crate)`) with ABI-stable integer constants; migrate `Dictionary` to `VarDictionary`.
- `src/plugin/input/dispatch.rs`: pass `GString` by reference to satisfy `AsArg<Variant>` (`Pass = ByRef`).
- Multiple files: drop unnecessary `mut` on editor handles and simplify `get_class().to_string() == "..."` comparisons (clippy).

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy` — no warnings
- [x] `cargo build` (debug)
- [ ] Manual smoke test in Godot 4.4 editor (open script editor, switch modes, run a keymap)
- [ ] CI passes on all release targets (Linux x64/arm64, Windows MinGW, macOS x86_64/arm64)