### PR TITLE
chore: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Upload commit as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: version-commit
           path: |
@@ -112,10 +112,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download and apply version updates
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: version-commit
 
@@ -132,7 +132,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
@@ -152,10 +152,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download and apply version updates
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: version-commit
 
@@ -168,7 +168,7 @@ jobs:
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.target }}
           path: target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
@@ -181,12 +181,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
 


### PR DESCRIPTION
## Summary
- Bump GitHub Actions to the first releases that run on Node.js 24, resolving the deprecation warning surfaced when running the Release workflow.
- Minimal major-version bumps only: pick the earliest Node-24 tag for each action to avoid unrelated behavior changes.

## Changes
- `actions/checkout` v4 -> v5 (first Node 24 release)
- `actions/upload-artifact` v4 -> v6 (first Node 24 release)
- `actions/download-artifact` v4 -> v7 (first Node 24 release)

Node.js 20 will be forced off runners on June 2nd, 2026, and fully removed on September 16th, 2026 (see the [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)).

## Test plan
- [ ] CI workflow passes on this PR
- [ ] Trigger Release workflow on a throwaway tag to confirm upload/download-artifact still work end-to-end