### PR TITLE
fix: insert composed Alt characters as text on macOS

### DIFF
--- a/src/plugin/input/insert.rs
+++ b/src/plugin/input/insert.rs
@@ -54,7 +54,10 @@ impl GodotNeovimPlugin {
         // These should NOT be sent to Neovim - let Godot buffer them instead
         let ctrl = key_event.is_ctrl_pressed();
         let alt = key_event.is_alt_pressed();
-        if ctrl || alt {
+        // macOS Option key composes characters (e.g. Option+Q → @): the OS
+        // produces the composed unicode while still flagging Alt. Treat that
+        // as plain text input so Godot inserts the composed character.
+        if (ctrl || alt) && !self.is_alt_composed_unicode(key_event) {
             let nvim_key = self.key_event_to_nvim_notation(key_event);
             // Only send if it's an actual Vim command notation (starts with <)
             // Plain characters (including CJK) should be handled by Godot

--- a/src/plugin/input/replace.rs
+++ b/src/plugin/input/replace.rs
@@ -31,7 +31,10 @@ impl GodotNeovimPlugin {
         // IME like CorvusSKK may report composed characters with ctrl modifier still set
         let ctrl = key_event.is_ctrl_pressed();
         let alt = key_event.is_alt_pressed();
-        if ctrl || alt {
+        // macOS Option key composes characters (e.g. Option+Q → @): the OS
+        // produces the composed unicode while still flagging Alt. Treat that
+        // as plain text input so Godot performs the overwrite below.
+        if (ctrl || alt) && !self.is_alt_composed_unicode(key_event) {
             let nvim_key = self.key_event_to_nvim_notation(key_event);
             // Only send if it's an actual Vim command notation (starts with <)
             if !nvim_key.is_empty() && nvim_key.starts_with('<') {

--- a/src/plugin/keys.rs
+++ b/src/plugin/keys.rs
@@ -3,9 +3,30 @@
 use super::GodotNeovimPlugin;
 use godot::classes::InputEventKey;
 use godot::global::Key;
+use godot::obj::EngineEnum;
 use godot::prelude::*;
 
 impl GodotNeovimPlugin {
+    /// Detect whether the OS has already produced a composed character via Alt
+    /// (e.g. macOS Option+Q → `@` on certain layouts). In that case the user
+    /// wants the produced character inserted as text, not `<A-x>` sent to Neovim.
+    pub(super) fn is_alt_composed_unicode(&self, event: &Gd<InputEventKey>) -> bool {
+        if !event.is_alt_pressed() || event.is_ctrl_pressed() {
+            return false;
+        }
+        let unicode = event.get_unicode();
+        if unicode == 0 {
+            return false;
+        }
+        let Some(uc) = char::from_u32(unicode) else {
+            return false;
+        };
+        let Some(kc) = char::from_u32(event.get_keycode().ord() as u32) else {
+            return false;
+        };
+        kc.to_ascii_lowercase() != uc.to_ascii_lowercase()
+    }
+
     /// Convert Godot key event to Neovim key string
     pub(super) fn key_event_to_nvim_string(&self, event: &Gd<InputEventKey>) -> Option<String> {
         let keycode = event.get_keycode();


### PR DESCRIPTION
## Summary
- Fix macOS Option+Q (and similar OS-composed key inputs) accidentally exiting Insert/Replace mode
- Godot passes the composed unicode while still setting `is_alt_pressed()=true`, so the plugin sent `<A-@>` to Neovim. Neovim treated the unmapped notation as `<Esc>@`, exiting Insert mode and trying to play the `@` register as a macro
- Detect OS-side composition by comparing `keycode` and `unicode` (case-insensitive ASCII). When they differ, skip the `<A-x>` notation path and let Godot insert the composed character as plain text

## Test plan
- [ ] On macOS with a layout where Option composes characters (e.g. Spanish ISO), press Option+Q in Insert mode and confirm `@` is inserted without leaving Insert mode
- [ ] Confirm the same works in Replace mode (overwrite)
- [ ] Confirm regular Alt+letter `<A-x>` mappings still fire on Linux/Windows
- [ ] Confirm Ctrl+Alt combinations (e.g. AltGr) still go through as `<C-A-x>` as before

Fixes #70