### PR TITLE
fix: insert composed Alt characters on Windows AltGr layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,15 @@ Insert mode uses Godot's native input system to support auto-completion and othe
 - **Dot repeat**: `.` does not repeat `Ctrl+/`
 - **Undo**: Uses Godot's undo system, not Neovim's `u`
 
+### Alt Key Composition (Option / AltGr)
+
+When the OS produces a composed character via the Alt modifier (e.g. macOS Option+Q → `@`, Windows AltGr+Q → `@` on German layout), the plugin inserts the composed character as plain text instead of sending `<A-x>` / `<C-A-x>` to Neovim. This makes layouts that rely on Alt for character composition usable in Insert and Replace modes.
+
+As a side effect, the following Vim mappings are unreachable on those layouts:
+
+- **macOS**: Any `<A-letter>` mapping where Option+letter produces a character on the active layout. Configure macOS to "Use Option as Meta key" in your terminal/editor or switch to a layout that does not compose to use these mappings.
+- **Windows (AltGr layouts, e.g. German/French/Spanish)**: `<C-A-letter>` mappings on keys that AltGr composes. Windows reports AltGr as Ctrl+Alt simultaneously at the OS level, so AltGr+Q and Ctrl+Alt+Q are indistinguishable from any application. Use a different modifier combination or disable AltGr to use these mappings.
+
 ### Known Issues
 
 | Issue | Workaround |

--- a/src/plugin/input/insert.rs
+++ b/src/plugin/input/insert.rs
@@ -54,9 +54,10 @@ impl GodotNeovimPlugin {
         // These should NOT be sent to Neovim - let Godot buffer them instead
         let ctrl = key_event.is_ctrl_pressed();
         let alt = key_event.is_alt_pressed();
-        // macOS Option key composes characters (e.g. Option+Q → @): the OS
-        // produces the composed unicode while still flagging Alt. Treat that
-        // as plain text input so Godot inserts the composed character.
+        // macOS Option and Windows AltGr compose characters (e.g. Option+Q →
+        // @, AltGr+Q → @ on German layout): the OS produces the composed
+        // unicode while still flagging Alt. Treat that as plain text input
+        // so Godot inserts the composed character.
         if (ctrl || alt) && !self.is_alt_composed_unicode(key_event) {
             let nvim_key = self.key_event_to_nvim_notation(key_event);
             // Only send if it's an actual Vim command notation (starts with <)

--- a/src/plugin/input/replace.rs
+++ b/src/plugin/input/replace.rs
@@ -31,9 +31,10 @@ impl GodotNeovimPlugin {
         // IME like CorvusSKK may report composed characters with ctrl modifier still set
         let ctrl = key_event.is_ctrl_pressed();
         let alt = key_event.is_alt_pressed();
-        // macOS Option key composes characters (e.g. Option+Q → @): the OS
-        // produces the composed unicode while still flagging Alt. Treat that
-        // as plain text input so Godot performs the overwrite below.
+        // macOS Option and Windows AltGr compose characters (e.g. Option+Q →
+        // @, AltGr+Q → @ on German layout): the OS produces the composed
+        // unicode while still flagging Alt. Treat that as plain text input
+        // so Godot performs the overwrite below.
         if (ctrl || alt) && !self.is_alt_composed_unicode(key_event) {
             let nvim_key = self.key_event_to_nvim_notation(key_event);
             // Only send if it's an actual Vim command notation (starts with <)

--- a/src/plugin/keys.rs
+++ b/src/plugin/keys.rs
@@ -8,10 +8,15 @@ use godot::prelude::*;
 
 impl GodotNeovimPlugin {
     /// Detect whether the OS has already produced a composed character via Alt
-    /// (e.g. macOS Option+Q → `@` on certain layouts). In that case the user
-    /// wants the produced character inserted as text, not `<A-x>` sent to Neovim.
+    /// (e.g. macOS Option+Q → `@`, or AltGr+Q → `@` on Windows German layout).
+    /// In that case the user wants the produced character inserted as text,
+    /// not `<A-x>` / `<C-A-x>` sent to Neovim.
+    ///
+    /// Note: Windows reports AltGr as Ctrl+Alt simultaneously, so we don't
+    /// exclude ctrl here. IME like CorvusSKK reports composed characters with
+    /// only ctrl set (no alt), so requiring alt avoids interfering with them.
     pub(super) fn is_alt_composed_unicode(&self, event: &Gd<InputEventKey>) -> bool {
-        if !event.is_alt_pressed() || event.is_ctrl_pressed() {
+        if !event.is_alt_pressed() {
             return false;
         }
         let unicode = event.get_unicode();


### PR DESCRIPTION
## Summary
- Extend the macOS Option fix (#70 / #71) so Windows AltGr layouts (German, French, Spanish, etc.) can also insert composed characters in Insert/Replace mode (e.g. AltGr+Q → \`@\`, AltGr+E → \`€\`)
- Windows reports AltGr as Ctrl+Alt simultaneously at the OS level. Drop the \`is_ctrl_pressed()\` early-return in \`is_alt_composed_unicode\` so AltGr-composed input falls through to Godot. \`is_alt_pressed()\` is still required, which keeps IME like CorvusSKK (ctrl-without-alt) unaffected
- Document the residual limitation in README: \`<C-A-letter>\` Vim mappings cannot be triggered on AltGr-composing keys because Windows itself cannot distinguish AltGr from Ctrl+Alt

## Behavior matrix

| Input | Result |
|---|---|
| AltGr+Q on German Windows | \`@\` inserted (was: sent \`<C-A-@>\` to Neovim) |
| Option+Q on Spanish macOS | \`@\` inserted (already fixed in #71) |
| Alt+letter (no compose) | \`<A-letter>\` sent to Neovim (unchanged) |
| Ctrl+Alt+letter (no compose) | \`<C-A-letter>\` sent to Neovim (unchanged) |
| Ctrl+letter | \`<C-letter>\` sent to Neovim (unchanged) |
| CorvusSKK Ctrl+CJK | passes through to Godot (unchanged) |

## Test plan
- [ ] On Windows with German layout, type AltGr+Q in Insert mode and confirm \`@\` is inserted without exiting Insert mode
- [ ] Confirm AltGr+E inserts \`€\` on the same layout
- [ ] Confirm regular \`<A-letter>\` mapping still fires on layouts without Alt composition
- [ ] Confirm \`<C-letter>\` (e.g. \`<C-w>\` in command-line) still works
- [ ] Confirm CorvusSKK / IME composition is not broken (Ctrl modifier with composed CJK passes through)

Follow-up to #70.