### PR TITLE
Fix: Let CTRL+special keys pass through to Godot in insert mode

### DIFF
--- a/src/plugin/input/insert.rs
+++ b/src/plugin/input/insert.rs
@@ -59,6 +59,28 @@ impl GodotNeovimPlugin {
         // unicode while still flagging Alt. Treat that as plain text input
         // so Godot inserts the composed character.
         if (ctrl || alt) && !self.is_alt_composed_unicode(key_event) {
+            // Let Ctrl/Shift+special keys (Backspace, Delete, arrows, Home, End)
+            // pass through to Godot in insert mode. Godot's CodeEdit handles these
+            // natively (e.g., Ctrl+Backspace = delete word, Ctrl+Delete = delete word
+            // forward, Ctrl+Left/Right = word navigation, Shift+arrows = selection).
+            // Sending these to Neovim causes buffer desync since Neovim edits its own
+            // buffer while Godot owns the text in insert mode.
+            let keycode = key_event.get_keycode();
+            let is_special_nav_key = matches!(
+                keycode,
+                Key::BACKSPACE
+                    | Key::DELETE
+                    | Key::LEFT
+                    | Key::RIGHT
+                    | Key::UP
+                    | Key::DOWN
+                    | Key::HOME
+                    | Key::END
+            );
+            if is_special_nav_key {
+                return;
+            }
+
             let nvim_key = self.key_event_to_nvim_notation(key_event);
             // Only send if it's an actual Vim command notation (starts with <)
             // Plain characters (including CJK) should be handled by Godot


### PR DESCRIPTION
### Tested with:
Godot-Neovim: v1.0.3
Neovim: v0.12.2
Godot: v4.6.2.stable.arch_linux [001aa128b]

### Problem
When deleting with `CTRL`+`Backspace` in insert mode, the whole line gets deleted (instead of a single word, as expected).

### Fix
Propose to delegate `CTRL` + `special keys` (for deletion and movement) in insert mode back to letting Godot handle it natively.