### PR TITLE
fix: false "Neovim not responding" dialog on no-op movement keys

### DIFF
--- a/src/neovim/client/connection.rs
+++ b/src/neovim/client/connection.rs
@@ -37,6 +37,8 @@ impl NeovimClient {
             io_handle: None,
             key_input_tx: None,
             key_input_handle: None,
+            keys_processed: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            keys_processed_seen: std::sync::atomic::AtomicU64::new(0),
         })
     }
 
@@ -152,14 +154,41 @@ impl NeovimClient {
 
         // Spawn key input processor task
         let neovim_arc = self.neovim.clone();
+        let keys_processed = self.keys_processed.clone();
         let key_input_handle = self.runtime.spawn(async move {
             while let Some(keys) = rx.recv().await {
                 let nvim_lock = neovim_arc.lock().await;
                 if let Some(neovim) = nvim_lock.as_ref() {
-                    if let Err(e) = neovim.input(&keys).await {
-                        // Log error but continue processing
-                        // Note: Can't use godot_error here (tokio thread)
-                        eprintln!("[godot-neovim] Failed to send key '{}': {}", keys, e);
+                    match neovim.input(&keys).await {
+                        // nvim_input returns the number of bytes written.
+                        // Ok(0) means the typeahead buffer was full and the key
+                        // was silently dropped — do NOT count that as an ack.
+                        Ok(n) if n > 0 => {
+                            // nvim_input is FUNC_API_FAST: it is answered from
+                            // Neovim's fast event context even while the main
+                            // loop is hung, so its Ok alone proves nothing.
+                            // Follow up with a deferred (non-fast) request that
+                            // only the main loop can answer; advance the
+                            // processed counter only when it completes. A no-op
+                            // key (e.g. `j` at the last line) still acks here,
+                            // while a genuine main-loop hang stalls the counter
+                            // and lets the plugin's watchdog fire (see #75).
+                            if neovim.eval("1").await.is_ok() {
+                                keys_processed
+                                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                            }
+                        }
+                        Ok(_) => {
+                            // Note: Can't use godot_error here (tokio thread)
+                            eprintln!(
+                                "[godot-neovim] Key '{}' dropped: Neovim typeahead buffer full",
+                                keys
+                            );
+                        }
+                        Err(e) => {
+                            // Log error but continue processing
+                            eprintln!("[godot-neovim] Failed to send key '{}': {}", keys, e);
+                        }
                     }
                 }
                 // Release lock before next iteration

--- a/src/neovim/client/mod.rs
+++ b/src/neovim/client/mod.rs
@@ -18,7 +18,7 @@ mod state;
 use crate::neovim::{NeovimHandler, NeovimState};
 use nvim_rs::Neovim;
 use std::fmt;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::UnboundedSender;
@@ -153,6 +153,21 @@ pub struct NeovimClient {
     /// Key input processor task handle
     #[allow(dead_code)]
     pub(super) key_input_handle: Option<tokio::task::JoinHandle<()>>,
+    /// Monotonic counter of keys confirmed processed by Neovim's main loop.
+    /// The key-input worker increments this only after (a) nvim_input accepted
+    /// the key (returned bytes written > 0 — Ok(0) means the typeahead buffer
+    /// was full and the key was dropped) AND (b) a follow-up deferred request
+    /// (nvim_eval) completed. nvim_input alone is FUNC_API_FAST and is answered
+    /// even while the main loop is hung, so only the eval round-trip proves the
+    /// main loop is alive. This lets the plugin distinguish a genuine hang from
+    /// a legitimately-ignored key (e.g. `j` at the last line — see #75).
+    pub(super) keys_processed: Arc<AtomicU64>,
+    /// Last keys_processed value consumed by take_keys_processed_delta().
+    /// Lives on the client (not the plugin) so each Neovim instance tracks its
+    /// own baseline — switching between script/shader editors or restarting a
+    /// client can never produce a spurious ack from comparing counters of two
+    /// different instances.
+    pub(super) keys_processed_seen: AtomicU64,
 }
 
 impl Default for NeovimClient {

--- a/src/neovim/client/state.rs
+++ b/src/neovim/client/state.rs
@@ -91,6 +91,19 @@ impl NeovimClient {
         });
     }
 
+    /// Number of keys Neovim's main loop has confirmed processing since the
+    /// last call (see keys_processed in mod.rs for what "confirmed" means).
+    /// The baseline is stored on this client, so counters of different Neovim
+    /// instances (script vs shader, or a restarted client) are never compared
+    /// against each other. A non-zero delta proves this instance is alive even
+    /// without any visible redraw — e.g. a no-op motion at the end of the file
+    /// (#75) — and the caller can subtract it from its pending-key count.
+    pub fn take_keys_processed_delta(&self) -> u64 {
+        let current = self.keys_processed.load(Ordering::SeqCst);
+        let seen = self.keys_processed_seen.swap(current, Ordering::SeqCst);
+        current.saturating_sub(seen)
+    }
+
     /// Take pending debug messages from Lua
     /// Returns empty Vec if no messages
     pub fn take_debug_messages(&self) -> Vec<String> {

--- a/src/plugin/neovim.rs
+++ b/src/plugin/neovim.rs
@@ -725,7 +725,7 @@ impl GodotNeovimPlugin {
         }
 
         // Collect data from Neovim while holding lock, then release and process
-        let (state_from_redraw, buf_events, viewport_change, debug_messages) = {
+        let (state_from_redraw, buf_events, viewport_change, debug_messages, keys_acked) = {
             let Some(neovim) = self.get_current_neovim() else {
                 return;
             };
@@ -734,7 +734,9 @@ impl GodotNeovimPlugin {
                 return;
             };
 
-            // Poll the runtime to process async events (including redraw)
+            // Poll the runtime to process async events (including redraw).
+            // This also gives the key-input worker task a chance to drain queued
+            // keys and call nvim_input, advancing keys_processed below.
             client.poll();
 
             // Collect buffer events
@@ -769,11 +771,17 @@ impl GodotNeovimPlugin {
             // Get debug messages from Lua
             let debug_messages = client.take_debug_messages();
 
+            // Keys this client's main loop confirmed since last frame. Advances
+            // even when a key changes nothing on screen (no-op motion at EOF),
+            // but stalls on a genuine main-loop hang — see connection.rs.
+            let keys_acked = client.take_keys_processed_delta();
+
             (
                 state_from_redraw,
                 buf_events,
                 viewport_change,
                 debug_messages,
+                keys_acked,
             )
         };
         // Lock is now released
@@ -791,6 +799,25 @@ impl GodotNeovimPlugin {
             // Got response, reset pending key tracking
             self.pending_key_count = 0;
             self.last_key_send_time = None;
+        } else if keys_acked > 0 {
+            // No visible change, but Neovim's main loop confirmed processing
+            // keys (each ack requires a deferred eval round-trip) — it is alive
+            // even though the keys were no-ops (e.g. `j` at the last line, #75).
+            // Subtract only the acked keys so partial progress does not disarm
+            // the watchdog while other keys are still stuck in the queue.
+            // May over-subtract for channel sends that bypass send_keys
+            // (send_escape, pending_keys_after_exit) — saturating_sub keeps
+            // that benign, and those acks are genuine life signs anyway.
+            self.pending_key_count = self
+                .pending_key_count
+                .saturating_sub(u32::try_from(keys_acked).unwrap_or(u32::MAX));
+            if self.pending_key_count == 0 {
+                self.last_key_send_time = None;
+            } else {
+                // Fresh sign of life: restart the no-response window for the
+                // keys that remain pending.
+                self.last_key_send_time = Some(std::time::Instant::now());
+            }
         } else if let Some(send_time) = self.last_key_send_time {
             // No response - check if we've been waiting too long
             use crate::neovim::TIMEOUT_RECOVERY_WINDOW_SECS;


### PR DESCRIPTION
## Summary

Fixes #75.

Navigating beyond the end of the file (e.g. pressing `jj` or `ll` at the last line) and then pausing for a few seconds triggered the "Neovim is not responding" recovery dialog, even though Neovim was alive and well.

## Root cause

The no-response watchdog treated "no visible redraw after a key" as evidence that Neovim hung. A movement key that legitimately changes nothing (cursor already at the end of the file) emits no redraw / cursor / viewport / buf_lines event, so `pending_key_count` kept accumulating and the recovery dialog fired after `TIMEOUT_RECOVERY_WINDOW_SECS` (5s) once 3+ keys were pending.

## Fix

Replace the redraw-only heuristic with a per-client ack counter that proves Neovim's main loop actually processed the queued input:

- The key-input worker advances `keys_processed` only after `nvim_input` accepted the key (`Ok(n > 0)`; `Ok(0)` means the typeahead buffer was full and the key was dropped) **and** a follow-up `nvim_eval("1")` completed. `nvim_input` is `FUNC_API_FAST` and is answered even while the main loop is hung, so only the deferred eval round-trip proves liveness.
- The read baseline (`keys_processed_seen`) lives on the client itself, so the script/shader instances or a restarted client never compare counters of different instances (no spurious ack on editor switch or after recovery).
- The watchdog subtracts only the acked delta from `pending_key_count` instead of fully resetting, so partial progress does not disarm detection of keys still stuck in the queue.

A genuine hang still stalls the counter and shows the recovery dialog (3+ pending keys, 5 seconds), preserving the original recovery path.

## Testing

- `cargo build` / `cargo clippy` pass (the remaining `manual_ignore_case_cmp` warning in `keys.rs` is pre-existing on `main` and unrelated).
- Manual verification in the Godot editor:
  - `G` then `jj` at the last line, wait 10+ seconds → no recovery dialog, movement keys keep working.
  - Suspend `nvim.exe`, press `j` 3+ times, wait 5 seconds → recovery dialog still appears (true-hang detection preserved).