### PR TITLE
fix: crash when opening the Neovim executable path picker

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,14 +1,12 @@
 use godot::classes::{EditorInterface, EditorSettings};
 use godot::prelude::*;
+use godot::register::info::PropertyHint;
 use std::path::Path;
 use std::process::{Command, Output};
 
 const SETTING_NEOVIM_PATH: &str = "godot_neovim/neovim_executable_path";
 const SETTING_NEOVIM_CLEAN: &str = "godot_neovim/neovim_clean";
 const SETTING_TIMEOUTLEN: &str = "godot_neovim/timeoutlen";
-
-const PROPERTY_HINT_RANGE: i32 = 1;
-const PROPERTY_HINT_GLOBAL_FILE: i32 = 23;
 
 /// Default timeout for multi-key sequences (matches Neovim's default)
 pub const DEFAULT_TIMEOUTLEN_MS: i64 = 1000;
@@ -50,7 +48,7 @@ pub fn initialize_settings() {
     let mut property_info = VarDictionary::new();
     property_info.set("name", SETTING_NEOVIM_PATH);
     property_info.set("type", VariantType::STRING.ord());
-    property_info.set("hint", PROPERTY_HINT_GLOBAL_FILE);
+    property_info.set("hint", PropertyHint::GLOBAL_FILE.ord());
     property_info.set("hint_string", &get_file_filter());
 
     settings.add_property_info(&property_info);
@@ -87,7 +85,7 @@ pub fn initialize_settings() {
     let mut timeoutlen_info = VarDictionary::new();
     timeoutlen_info.set("name", SETTING_TIMEOUTLEN);
     timeoutlen_info.set("type", VariantType::INT.ord());
-    timeoutlen_info.set("hint", PROPERTY_HINT_RANGE);
+    timeoutlen_info.set("hint", PropertyHint::RANGE.ord());
     timeoutlen_info.set("hint_string", "0,10000,100"); // min, max, step
 
     settings.add_property_info(&timeoutlen_info);


### PR DESCRIPTION
## Summary

Pressing the button next to `Editor Settings > Godot Neovim > Neovim Executable Path` crashed the Godot editor with:

```
ERROR: FATAL: Condition "!exists" is true.
   at: operator[] (./core/templates/hash_map.h:554)
```

The reporter hit this on Void Linux / Flatpak / Godot 4.7.1, but the bug is **platform independent** — it reproduces on a plain Windows build with the exact same fatal message.

Fixes #78

## Root cause

`src/settings.rs` hardcoded `PROPERTY_HINT_GLOBAL_FILE` as `23`. The correct value is `15`; **`23` is `PROPERTY_HINT_TYPE_STRING`**.

This was introduced in 0b59268 (`chore: upgrade godot-rs to 0.5 with api-4-4 feature`), which replaced `godot::global::PropertyHint::GLOBAL_FILE.ord()` with "ABI-stable integer constants". That replacement was never necessary: godot-rs 0.5 did not make `PropertyHint` private, it just moved it from `godot::global` to `godot::register::info`.

The crash path on the Godot side:

1. With hint 23, `EditorInspectorDefaultPlugin` builds an `EditorPropertyClassName` instead of an `EditorPropertyPath` (`editor/inspector/editor_properties.cpp`)
2. Its base type is set from `hint_string`, so it becomes `"*"` (`"*.exe"` on Windows) — not a real class
3. Pressing the button runs `CreateDialog::popup_create()` → `_update_search()` → `_configure_search_option_item()`
4. The type is in neither `ClassDB` nor `ScriptServer`, so it falls into the custom-type branch and evaluates `EditorNode::get_editor_data().get_custom_types()[custom_type_parents[p_type]]`
5. `get_custom_types()` returns a **const** reference (`editor/editor_data.h`), so the const `HashMap::operator[]` runs, the key is missing, and `CRASH_COND(!exists)` fires

The same line exists in `4.4-stable:editor/create_dialog.cpp`, so every supported Godot version is affected.

## Fix

Drop the magic numbers and use the generated constants:

```rust
use godot::register::info::PropertyHint;

property_info.set("hint", PropertyHint::GLOBAL_FILE.ord());
timeoutlen_info.set("hint", PropertyHint::RANGE.ord());
```

`RANGE` already had the correct value (`1`), but is converted too so the values cannot drift again.

## Verification

Verified end to end on Windows 11 with a Godot editor build, using an `EditorPlugin` probe that inspects the widget `EditorSettings` builds for `godot_neovim/neovim_executable_path` and then presses its button. Same project, same probe, only the dll swapped:

| dll | hint | widget | button press | exit code |
|---|---|---|---|---|
| before | 23 | `EditorPropertyClassName` | `FATAL: Condition "!exists" is true.` → `Program crashed` | 3 |
| after | 15 | `EditorPropertyPath` | no crash | 0 |

A minimal probe on a bare `STRING` property (hint varied, nothing else) confirms the mapping independently: hint 15 → `EditorPropertyPath`, hint 23 → `EditorPropertyClassName`.

## Affected versions

v1.0.2 through v1.0.5 (introduced 2026-04-12, v1.0.1 and earlier are fine).

## Note for Flatpak users

After this fix the setting opens a file dialog. Godot's own dialog (`interface/editor/use_native_file_dialogs` is off by default) only lists paths visible inside the Flatpak sandbox, so reaching a host `/usr/bin/nvim` may still require sandbox permissions. That is outside the plugin's control — but `EditorPropertyPath` also provides a text field, so the path can always be typed in manually.

## Workaround for unpatched versions

Disable the plugin so `add_property_info` is never applied. The setting then renders as a plain string property with a text field; type the path there and re-enable the plugin.

https://claude.ai/code/session_013zJa6CBUdeAqLHRNAgkvNP
